### PR TITLE
Fix: normalize class names

### DIFF
--- a/app/Http/Controllers/ClientController.php
+++ b/app/Http/Controllers/ClientController.php
@@ -4,9 +4,9 @@ namespace App\Http\Controllers;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
-use App\Models\client;
-use App\Models\invoice;
-use App\Models\project;
+use App\Models\Client;
+use App\Models\Invoice;
+use App\Models\Project;
 
 use Illuminate\Support\Facades\Auth;
 
@@ -19,7 +19,7 @@ class ClientController extends Controller
 
     public function addclientsave(Request $request)
     {       
-        $client =new client();
+        $client =new Client();
         $client->name =$request->name;
         $client->business =$request->business;
         $client->email =$request->email;
@@ -43,13 +43,13 @@ class ClientController extends Controller
 
     public function editclient(Request $request)
     {   
-        $client = client::findOrFail($request->id);
+        $client = Client::findOrFail($request->id);
         return view('app.editclient')->with(['client' =>$client]);     
     }
 
     public function editclientsave(Request $request)
     {       
-        $client = client::findOrFail($request->id);
+        $client = Client::findOrFail($request->id);
         $client->name =$request->name;
         $client->business =$request->business;
         $client->email =$request->email;
@@ -68,15 +68,15 @@ class ClientController extends Controller
 
     public function listofclients(Request $request)
     { 
-        $clients = client::orderby('id','desc')->paginate(15);     
+        $clients = Client::orderby('id','desc')->paginate(15);
         return view('app.listofclients')->with(['clients' =>$clients]);     
     }
 
     public function deleteclient(Request $request)
     { 
-       $client = client::findOrFail( $request->id);
-       $deleteinvoices = invoice::where('userid',$request->id)->delete();
-       $deleteprojects = project::where('client',$request->id)->delete();        
+       $client = Client::findOrFail( $request->id);
+       $deleteinvoices = Invoice::where('userid',$request->id)->delete();
+       $deleteprojects = Project::where('client',$request->id)->delete();
        $client->delete();
        return redirect('/clients')->with('success', 'Client Profile Deleted'); 
     }
@@ -84,10 +84,10 @@ class ClientController extends Controller
     public function viewclient(Request $request)
     {   
       
-        $projects = project::where('client',$request->id)->orderBy('id','desc')->paginate(15);       
-        $client = client::findOrFail($request->id);
-        $invoices = invoice::where('userid',$request->id)->where('type',2)->orderby('id','desc')->paginate(10); 
-        $quotes = invoice::where('userid',$request->id)->where('type',1)->orderby('id','desc')->paginate(10);        
+        $projects = Project::where('client',$request->id)->orderBy('id','desc')->paginate(15);
+        $client = Client::findOrFail($request->id);
+        $invoices = Invoice::where('userid',$request->id)->where('type',2)->orderby('id','desc')->paginate(10);
+        $quotes = Invoice::where('userid',$request->id)->where('type',1)->orderby('id','desc')->paginate(10);
         return view('app.viewclient')->with(['client' =>$client])->with(['invoices' =>$invoices])->with(['quotes' =>$quotes])->with(['projects' =>$projects]);    
     }
 

--- a/app/Http/Controllers/InvoiceController.php
+++ b/app/Http/Controllers/InvoiceController.php
@@ -13,7 +13,7 @@ use Illuminate\Support\Facades\Mail;
 use App\Mail\InvoiceMail;
 use App\Mail\QuoteMail;
 use App\Models\Setting;
-use App\Models\Notifications;
+use App\Models\Notification;
 use App\Models\Project;
 use App\Models\ProjectTask;
 use App\Models\Business;
@@ -57,7 +57,7 @@ class InvoiceController extends Controller
 
         $tasks = ProjectTask::where('assignedto',Auth::id())->where('status',1)->orderby('id','desc')->get();
         $invoices = Invoice::where('invostatus','1')->orWhere('invostatus','2')->orderby('id','desc')->paginate(3);
-        $notifications = Notifications::where('status',1)->where('toid',Auth::id())->orderby('id','desc')->paginate(5);
+        $notifications = Notification::where('status',1)->where('toid',Auth::id())->orderby('id','desc')->paginate(5);
         return view('dashboard')->with(['invoices' =>$invoices])->with(['clients'=> $client])->with('datas', $data)
         ->with('quotedata', $quotedata)->with('counts', $counts)->with('tasks', $tasks)->with('notifications', $notifications);  
     }

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -9,11 +9,11 @@ use Spatie\QueryBuilder\QueryBuilder;
 use App\Models\Project;
 use App\Models\ProjectTask;
 use App\Models\ProjectNote;
-use App\Models\ProjectUpdates;
+use App\Models\ProjectUpdate;
 use App\Models\User;
 use App\Models\Invoice;
-use App\Models\TaskTodos;
-use App\Models\Notifications;
+use App\Models\TaskTodo;
+use App\Models\Notification;
 use Illuminate\Support\Facades\Auth;
 use Carbon\Carbon;
 use App\Models\ExpenseManager;
@@ -62,7 +62,7 @@ class ProjectController extends Controller
     {         
         $client = Client::all();
         $project = Project::findOrFail($request->id);
-        $projectupdates = ProjectUpdates::where('projectid',$request->id)->orderby('id','desc')->paginate(5);
+        $projectupdates = ProjectUpdate::where('projectid',$request->id)->orderby('id','desc')->paginate(5);
         $startdate = Carbon::parse($project->startdate);
         $deadline = Carbon::parse($project->deadline);
         $totaldays =   $startdate->diffInDays($deadline);           
@@ -111,7 +111,7 @@ class ProjectController extends Controller
 
         //send notification 
         if($request->assignedto){
-            $notif =new Notifications();
+            $notif =new Notification();
             $notif->fromid =Auth::id();  
             $notif->toid =$request->assignedto;
             $notif->message ='New Project Task Assigned #'.$project->id;
@@ -127,7 +127,7 @@ class ProjectController extends Controller
 
     public function notificationupdate(Request $request)
     {   
-        $project = Notifications::findOrFail($request->id);
+        $project = Notification::findOrFail($request->id);
         $project->status =0;
         $project->save();     
         return redirect()->back()->with('success', 'Notification Updated');
@@ -201,7 +201,7 @@ class ProjectController extends Controller
 
     public function todostatusupdate(Request $request)
     {   
-        $project = TaskTodos::findOrFail($request->id);
+        $project = TaskTodo::findOrFail($request->id);
         $project->status = $request->status;     
         $project->save();     
         return redirect()->back()->with('success', 'Status Updated');
@@ -209,7 +209,7 @@ class ProjectController extends Controller
 
     public function tasktododelete(Request $request)
     {   
-        $project = TaskTodos::findOrFail($request->id);
+        $project = TaskTodo::findOrFail($request->id);
          $project->delete();
         return redirect()->back()->with('success', 'Status Updated');
     }
@@ -218,15 +218,15 @@ class ProjectController extends Controller
     public function viewtask(Request $request)
     {   
         $task = ProjectTask::where('assignedto',Auth::id())->where('id',$request->id)->firstOrFail();
-        $todos = TaskTodos::where('taskid',$request->id)->orderby('id','desc')->get();
-        $taskcomments =  ProjectUpdates::where('taskid',$request->id)->orderby('id','desc')->paginate(7);
+        $todos = TaskTodo::where('taskid',$request->id)->orderby('id','desc')->get();
+        $taskcomments =  ProjectUpdate::where('taskid',$request->id)->orderby('id','desc')->paginate(7);
         return view('app.viewtask')->with(['task' =>$task])->with(['todos' =>$todos])->with(['taskcomments' =>$taskcomments]);   
     }
 
        
     public function addtasktodo(Request $request)
     {   
-        $updates = new TaskTodos();
+        $updates = new TaskTodo();
         $updates->taskid =$request->taskid;   
         $updates->task =$request->task;   
         $updates->auth =Auth::id();  
@@ -241,7 +241,7 @@ class ProjectController extends Controller
 
     public function addprojectupdates(Request $request)
     {   
-        $updates = new ProjectUpdates();
+        $updates = new ProjectUpdate();
         $updates->projectid =$request->projectid;   
         $updates->taskid =$request->taskid;   
         $updates->auth =Auth::id();  
@@ -252,7 +252,7 @@ class ProjectController extends Controller
 
     public function editprojectupdates(Request $request)
     {   
-        $updates = ProjectUpdates::find($request->id);
+        $updates = ProjectUpdate::find($request->id);
         $updates->message =$request->message;     
         $updates->save();     
         return redirect()->back()->with('success', 'Comment Updated');
@@ -261,7 +261,7 @@ class ProjectController extends Controller
 
     public function deleteupdates(Request $request)
     {
-     $project = ProjectUpdates::findOrFail($request->id);
+     $project = ProjectUpdate::findOrFail($request->id);
      $project->delete();
      return redirect()->back()->with('success', ' Update Deleted');
     }

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -4,28 +4,28 @@ namespace App\Http\Controllers;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
-use App\Models\client;
+use App\Models\Client;
 use Spatie\QueryBuilder\QueryBuilder;
-use App\Models\project;
-use App\Models\projecttask;
-use App\Models\projectnote;
-use App\Models\projectupdates;
+use App\Models\Project;
+use App\Models\ProjectTask;
+use App\Models\ProjectNote;
+use App\Models\ProjectUpdates;
 use App\Models\User;
-use App\Models\invoice;
-use App\Models\tasktodos;
-use App\Models\notifications;
+use App\Models\Invoice;
+use App\Models\TaskTodos;
+use App\Models\Notifications;
 use Illuminate\Support\Facades\Auth;
 use Carbon\Carbon;
-use App\Models\expensemanager;
+use App\Models\ExpenseManager;
 
 
-class projectcontroller extends Controller
+class ProjectController extends Controller
 {
     
     public function listofprojects(Request $request)
     { 
-        $client = client::all();
-        $projects = QueryBuilder::for(project::class)
+        $client = Client::all();
+        $projects = QueryBuilder::for(Project::class)
         ->allowedFilters(['projectname','client','status'])
         ->orderBy('id','desc')->paginate(15);       
         return view('app.listofprojects')->with(['projects' =>$projects])->with(['clients'=> $client]);     
@@ -33,7 +33,7 @@ class projectcontroller extends Controller
 
     public function createnewproject(Request $request)
     {   
-        $project =new project();
+        $project =new Project();
         $project->projectname=$request->projectname;
         $project->client =$request->client;
         $project->description =$request->description;
@@ -42,7 +42,7 @@ class projectcontroller extends Controller
         $project->status =1;
         $project->save();        
         $lastid = $project->id;
-        $project =new projectnote();
+        $project =new ProjectNote();
         $project->pjid=$lastid;
         $project->admin = Auth::id();  
         $project->note ='Add Something';
@@ -53,16 +53,16 @@ class projectcontroller extends Controller
 
     public function deleteproject(Request $request)
     {
-     $project = project::findOrFail($request->id);      
+     $project = Project::findOrFail($request->id);
      $project->delete();
      return redirect('/projects')->with('success', 'Project Deleted');  
     }
 
     public function viewproject(Request $request)
     {         
-        $client = client::all();
-        $project = project::findOrFail($request->id);  
-        $projectupdates = projectupdates::where('projectid',$request->id)->orderby('id','desc')->paginate(5);
+        $client = Client::all();
+        $project = Project::findOrFail($request->id);
+        $projectupdates = ProjectUpdates::where('projectid',$request->id)->orderby('id','desc')->paginate(5);
         $startdate = Carbon::parse($project->startdate);
         $deadline = Carbon::parse($project->deadline);
         $totaldays =   $startdate->diffInDays($deadline);           
@@ -72,11 +72,11 @@ class projectcontroller extends Controller
         $percentage = $balancedays * 100 / $totaldays;
 
         $counts=[];
-        $counts['income']=invoice::where('projectid',$request->id)->sum('paidamount');
-        $counts['expense']=expensemanager::where('prid',$request->id)->sum('amount');
+        $counts['income']=Invoice::where('projectid',$request->id)->sum('paidamount');
+        $counts['expense']=ExpenseManager::where('prid',$request->id)->sum('amount');
         $counts['balance']= $counts['income'] - $counts['expense'];
         
-        $invoices = invoice::where('type',2)->where('projectid',$request->id)->orderby('id','desc')->paginate(3);   
+        $invoices = Invoice::where('type',2)->where('projectid',$request->id)->orderby('id','desc')->paginate(3);
 
         return view('app.projectview')->with(['project' =>$project])->with(['prid' =>$request->id])->with(['percentage' =>$percentage])
         ->with(['balancedays' =>$balancedays])->with(['invoices' =>$invoices])->with(['projectupdates' =>$projectupdates])->with('counts', $counts); 
@@ -84,23 +84,23 @@ class projectcontroller extends Controller
 
     public function viewtasks(Request $request)
     { 
-        $client = client::all();
+        $client = Client::all();
         $users = User::all();
-        $task = Projecttask::where('prid',$request->id)->paginate(30);                
+        $task = ProjectTask::where('prid',$request->id)->paginate(30);
         return view('app.projectviewtasks')->with(['tasks' =>$task])->with(['prid' =>$request->id])->with(['users' =>$users]);     
     }
 
     public function viewnote(Request $request)
     { 
-        $client = client::all();
-        $note = projectnote::where('pjid',$request->id)->first();            
+        $client = Client::all();
+        $note = ProjectNote::where('pjid',$request->id)->first();
         return view('app.projectviewnote')->with(['note' =>$note])->with(['prid' =>$request->id]);      
     }
     
 
     public function createprjcttask(Request $request)
     {   
-        $project =new projecttask();
+        $project =new ProjectTask();
         $project->prid=$request->prid;
         $project->aid = Auth::id();  
         $project->task =$request->task;
@@ -111,7 +111,7 @@ class projectcontroller extends Controller
 
         //send notification 
         if($request->assignedto){
-            $notif =new notifications();
+            $notif =new Notifications();
             $notif->fromid =Auth::id();  
             $notif->toid =$request->assignedto;
             $notif->message ='New Project Task Assigned #'.$project->id;
@@ -127,7 +127,7 @@ class projectcontroller extends Controller
 
     public function notificationupdate(Request $request)
     {   
-        $project = notifications::findOrFail($request->id);     
+        $project = Notifications::findOrFail($request->id);
         $project->status =0;
         $project->save();     
         return redirect()->back()->with('success', 'Notification Updated');
@@ -135,7 +135,7 @@ class projectcontroller extends Controller
 
     public function updatenote(Request $request)
     {   
-        $project = projectnote::findOrFail($request->id);       
+        $project = ProjectNote::findOrFail($request->id);
         $project->admin = Auth::id();  
         $project->note =$request->note;
         $project->save();     
@@ -144,7 +144,7 @@ class projectcontroller extends Controller
 
     public function projecttaskupdate(Request $request)
     {   
-        $project = projecttask::findOrFail($request->id);     
+        $project = ProjectTask::findOrFail($request->id);
         $project->status =$request->status;
         $project->save();     
         return redirect()->back()->with('success', 'Task Updated');
@@ -152,7 +152,7 @@ class projectcontroller extends Controller
 
     public function deletetasks(Request $request)
     {
-     $project = projecttask::findOrFail($request->id);      
+     $project = ProjectTask::findOrFail($request->id);
      $project->delete();
      return redirect()->back()->with('success', 'Task Deleted');
     }
@@ -160,7 +160,7 @@ class projectcontroller extends Controller
     
     public function updateproject(Request $request)
     {   
-        $project = project::findOrFail($request->id);     
+        $project = Project::findOrFail($request->id);
         $project->projectname =$request->projectname;      
         $project->startdate =$request->startdate;
         $project->deadline =$request->deadline;     
@@ -170,7 +170,7 @@ class projectcontroller extends Controller
 
     public function updateprojectdescript(Request $request)
     {   
-        $project = project::findOrFail($request->id);         
+        $project = Project::findOrFail($request->id);
         $project->description =$request->description;   
         $project->save();     
         return redirect()->back()->with('success', 'Project Updated');
@@ -179,7 +179,7 @@ class projectcontroller extends Controller
     
     public function projectstatuschange(Request $request)
     {   
-        $project = project::findOrFail($request->id);       
+        $project = Project::findOrFail($request->id);
         $project->status =$request->status;     
         $project->save();     
         return redirect()->back()->with('success', 'Status Updated');
@@ -187,13 +187,13 @@ class projectcontroller extends Controller
 
     public function mytasks(Request $request)
     {   
-        $task = Projecttask::where('assignedto',Auth::id())->orderby('id','desc')->paginate(20);                
+        $task = ProjectTask::where('assignedto',Auth::id())->orderby('id','desc')->paginate(20);
         return view('app.mytasks')->with(['tasks' =>$task]);   
     } 
     
     public function taskcomplete(Request $request)
     {   
-        $project = Projecttask::findOrFail($request->id);       
+        $project = ProjectTask::findOrFail($request->id);
         $project->status =2;     
         $project->save();     
         return redirect()->back()->with('success', 'Status Updated');
@@ -201,7 +201,7 @@ class projectcontroller extends Controller
 
     public function todostatusupdate(Request $request)
     {   
-        $project = tasktodos::findOrFail($request->id);       
+        $project = TaskTodos::findOrFail($request->id);
         $project->status = $request->status;     
         $project->save();     
         return redirect()->back()->with('success', 'Status Updated');
@@ -209,7 +209,7 @@ class projectcontroller extends Controller
 
     public function tasktododelete(Request $request)
     {   
-        $project = tasktodos::findOrFail($request->id);       
+        $project = TaskTodos::findOrFail($request->id);
          $project->delete();
         return redirect()->back()->with('success', 'Status Updated');
     }
@@ -217,16 +217,16 @@ class projectcontroller extends Controller
 
     public function viewtask(Request $request)
     {   
-        $task = Projecttask::where('assignedto',Auth::id())->where('id',$request->id)->firstOrFail();         
-        $todos = tasktodos::where('taskid',$request->id)->orderby('id','desc')->get();           
-        $taskcomments =  projectupdates::where('taskid',$request->id)->orderby('id','desc')->paginate(7);          
+        $task = ProjectTask::where('assignedto',Auth::id())->where('id',$request->id)->firstOrFail();
+        $todos = TaskTodos::where('taskid',$request->id)->orderby('id','desc')->get();
+        $taskcomments =  ProjectUpdates::where('taskid',$request->id)->orderby('id','desc')->paginate(7);
         return view('app.viewtask')->with(['task' =>$task])->with(['todos' =>$todos])->with(['taskcomments' =>$taskcomments]);   
     }
 
        
     public function addtasktodo(Request $request)
     {   
-        $updates = new tasktodos();         
+        $updates = new TaskTodos();
         $updates->taskid =$request->taskid;   
         $updates->task =$request->task;   
         $updates->auth =Auth::id();  
@@ -241,7 +241,7 @@ class projectcontroller extends Controller
 
     public function addprojectupdates(Request $request)
     {   
-        $updates = new projectupdates();         
+        $updates = new ProjectUpdates();
         $updates->projectid =$request->projectid;   
         $updates->taskid =$request->taskid;   
         $updates->auth =Auth::id();  
@@ -252,7 +252,7 @@ class projectcontroller extends Controller
 
     public function editprojectupdates(Request $request)
     {   
-        $updates = projectupdates::find($request->id); 
+        $updates = ProjectUpdates::find($request->id);
         $updates->message =$request->message;     
         $updates->save();     
         return redirect()->back()->with('success', 'Comment Updated');
@@ -261,7 +261,7 @@ class projectcontroller extends Controller
 
     public function deleteupdates(Request $request)
     {
-     $project = projectupdates::findOrFail($request->id);      
+     $project = ProjectUpdates::findOrFail($request->id);
      $project->delete();
      return redirect()->back()->with('success', ' Update Deleted');
     }
@@ -271,8 +271,8 @@ class projectcontroller extends Controller
 
     public function viewprojectexpense(Request $request)
     { 
-        $projects = project::all();
-         $expenses = QueryBuilder::for(expensemanager::class)
+        $projects = Project::all();
+         $expenses = QueryBuilder::for(ExpenseManager::class)
          ->allowedFilters(['prid','date','status'])
          ->where('prid',$request->id)->orderBy('id','desc')->paginate(15);   
          return view('app.projectexpenses')->with(['expenses' =>$expenses])->with(['projects'=> $projects])->with(['prid' =>$request->id]);         
@@ -281,7 +281,7 @@ class projectcontroller extends Controller
 
     public function deleteexpense(Request $request)
     {
-     $expense = expensemanager::findOrFail($request->id);      
+     $expense = ExpenseManager::findOrFail($request->id);
      $expense->delete();
      return redirect()->back()->with('success', ' Expense Deleted');
     }

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -3,20 +3,20 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
-use App\Models\setting;
+use App\Models\Setting;
 use App\Models\User;
-use App\Models\business;
+use App\Models\Business;
 class SettingsController extends Controller
 {
     public function settings(Request $request)
     {
-       $setings = setting::first();
+       $setings = Setting::first();
        return view('settings.settings')->with(['settings' =>$setings]);
     }
     public function updatesettings(Request $request)
     {
         if($request->businessname!=NULL){
-            $settings =setting::find(1);
+            $settings =Setting::find(1);
             $settings->companyname =$request->businessname;  
             if($request->logo!=NULL) {               
                 $filename    = time().'.'.$request->logo->extension();  
@@ -30,14 +30,14 @@ class SettingsController extends Controller
 
     public function billingsetting(Request $request)
     {
-       $setings = setting::first();
+       $setings = Setting::first();
        return view('settings.billing')->with(['settings' =>$setings]);
     }
 
     public function billingsettingsave(Request $request)
     {
      
-            $settings =setting::find(1);            
+            $settings =Setting::find(1);
             $settings->prefix =$request->prefix;   
             $settings->suffix =$request->suffix;
             $settings->taxstatus =$request->taxstatus;   
@@ -51,14 +51,14 @@ class SettingsController extends Controller
 
     public function businesssetting(Request $request)
     {
-       $business = business::find(1);
+       $business = Business::find(1);
        return view('settings.business')->with(['business' =>$business]);
     }
 
     public function businesssettingsave(Request $request)
     {
      
-            $settings =business::find(1);            
+            $settings =Business::find(1);
             $settings->businessname =$request->businessname;   
             $settings->email =$request->email;
             $settings->contactnum =$request->contactnum;   
@@ -82,14 +82,14 @@ class SettingsController extends Controller
 
     public function invoicesettings(Request $request)
     {
-       $business = business::find(1);
+       $business = Business::find(1);
        return view('settings.invoicesettings')->with(['business' =>$business]);
     }
 
     public function invoicesettingssave(Request $request)
     {
      
-            $settings =business::find(1); 
+            $settings =Business::find(1);
             $settings->enablelogo =$request->enablelogo;       
             $headerimage = $request->headerimage;
             if($headerimage!=NULL) {               

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -37,7 +37,7 @@ class Kernel extends HttpKernel
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             \App\Http\Middleware\VerifyCsrfToken::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
-           // \Illuminate\Routing\Middleware\admin::class,
+           // \Illuminate\Routing\Middleware\Admin::class,
            \App\Http\Middleware\Localization::class,
         ],
 
@@ -64,7 +64,7 @@ class Kernel extends HttpKernel
         'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,        
-        'admin' => \App\Http\Middleware\admin::class,
+        'admin' => \App\Http\Middleware\Admin::class,
         
     ];
 }

--- a/app/Http/Middleware/Admin.php
+++ b/app/Http/Middleware/Admin.php
@@ -5,7 +5,7 @@ namespace App\Http\Middleware;
 use Closure;
 use Illuminate\Http\Request;
 
-class admin
+class Admin
 {
     /**
      * Handle an incoming request.

--- a/app/Mail/InvoiceMail.php
+++ b/app/Mail/InvoiceMail.php
@@ -5,10 +5,10 @@ namespace App\Mail;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Mail\Mailable;
-use Illuminate\Queue\SerializesModels;
 use App\Models\invoice;
+use Illuminate\Queue\SerializesModels;
 
-class quotemail extends Mailable
+class InvoiceMail extends Mailable
 {
     use Queueable, SerializesModels;
 
@@ -30,6 +30,6 @@ class quotemail extends Mailable
      */
     public function build()
     {
-        return $this->markdown('emails.quotemail')->subject('Here is Your Quote');
+        return $this->markdown('emails.invoicemail')->subject('Here is Your Invoice');
     }
 }

--- a/app/Mail/QuoteMail.php
+++ b/app/Mail/QuoteMail.php
@@ -5,10 +5,10 @@ namespace App\Mail;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Mail\Mailable;
-use App\Models\invoice;
 use Illuminate\Queue\SerializesModels;
+use App\Models\invoice;
 
-class invoicemail extends Mailable
+class QuoteMail extends Mailable
 {
     use Queueable, SerializesModels;
 
@@ -30,6 +30,6 @@ class invoicemail extends Mailable
      */
     public function build()
     {
-        return $this->markdown('emails.invoicemail')->subject('Here is Your Invoice');
+        return $this->markdown('emails.quotemail')->subject('Here is Your Quote');
     }
 }

--- a/app/Models/Business.php
+++ b/app/Models/Business.php
@@ -5,13 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-class projectupdates extends Model
+class Business extends Model
 {
     use HasFactory;
-
-    public function addedby()
-	{
-        return  $this->belongsto(User::class, 'auth', 'id');
-        
-    }
 }

--- a/app/Models/Client.php
+++ b/app/Models/Client.php
@@ -5,7 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-class business extends Model
+class Client extends Model
 {
     use HasFactory;
 }

--- a/app/Models/ExpenseManager.php
+++ b/app/Models/ExpenseManager.php
@@ -5,12 +5,14 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-class notifications extends Model
+class ExpenseManager extends Model
 {
     use HasFactory;
-    public function added()
+
+    public function projectdata()
 	{
-        return  $this->belongsto(User::class, 'fromid', 'id');
+        return  $this->belongsTo(Project::class, 'prid', 'id');
         
     }
+
 }

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -5,17 +5,17 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-class invoice extends Model
+class Invoice extends Model
 {
     use HasFactory;
     public function clientdata()
 	{
-        return  $this->belongsto(client::class, 'userid', 'id');
+        return  $this->belongsTo(Client::class, 'userid', 'id');
         
     }
     public function projectdata()
 	{
-        return  $this->belongsto(project::class, 'projectid', 'id');
+        return  $this->belongsTo(Project::class, 'projectid', 'id');
         
     }
 }

--- a/app/Models/InvoiceMeta.php
+++ b/app/Models/InvoiceMeta.php
@@ -5,7 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-class setting extends Model
+class InvoiceMeta extends Model
 {
     use HasFactory;
 }

--- a/app/Models/Notification.php
+++ b/app/Models/Notification.php
@@ -5,13 +5,12 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-class ProjectUpdates extends Model
+class Notification extends Model
 {
     use HasFactory;
-
-    public function addedby()
+    public function added()
 	{
-        return  $this->belongsTo(User::class, 'auth', 'id');
+        return  $this->belongsTo(User::class, 'fromid', 'id');
         
     }
 }

--- a/app/Models/Notifications.php
+++ b/app/Models/Notifications.php
@@ -5,13 +5,12 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-class tasktodos extends Model
+class Notifications extends Model
 {
     use HasFactory;
-
     public function added()
 	{
-        return  $this->belongsto(User::class, 'auth', 'id');
+        return  $this->belongsTo(User::class, 'fromid', 'id');
         
     }
 }

--- a/app/Models/PaymentGateway.php
+++ b/app/Models/PaymentGateway.php
@@ -5,12 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-class project extends Model
+class PaymentGateway extends Model
 {
     use HasFactory;
-    public function clientdata()
-	{
-        return  $this->belongsto(client::class, 'client', 'id');
-        
-    }
 }

--- a/app/Models/PaymentReceipt.php
+++ b/app/Models/PaymentReceipt.php
@@ -5,7 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-class paymentgateway extends Model
+class PaymentReceipt extends Model
 {
     use HasFactory;
 }

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -5,7 +5,12 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-class paymentrecepit extends Model
+class Project extends Model
 {
     use HasFactory;
+    public function clientdata()
+	{
+        return  $this->belongsTo(Client::class, 'client', 'id');
+        
+    }
 }

--- a/app/Models/ProjectNote.php
+++ b/app/Models/ProjectNote.php
@@ -5,13 +5,13 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-class projectnote extends Model
+class ProjectNote extends Model
 {
     use HasFactory;
 
     public function admindata()
 	{
-        return  $this->belongsto(User::class, 'admin', 'id');
+        return  $this->belongsTo(User::class, 'admin', 'id');
         
     }
 }

--- a/app/Models/ProjectTask.php
+++ b/app/Models/ProjectTask.php
@@ -20,7 +20,7 @@ class ProjectTask extends Model
     }
     public function comments()
 	{
-        return  $this->hasMany(ProjectUpdates::class, 'taskid', 'id');
+        return  $this->hasMany(ProjectUpdate::class, 'taskid', 'id');
         
     }
 }

--- a/app/Models/ProjectTask.php
+++ b/app/Models/ProjectTask.php
@@ -5,22 +5,22 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-class projecttask extends Model
+class ProjectTask extends Model
 {
     use HasFactory;
     public function admindata()
 	{
-        return  $this->belongsto(User::class, 'aid', 'id');
+        return  $this->belongsTo(User::class, 'aid', 'id');
         
     }
     public function assigned()
 	{
-        return  $this->belongsto(User::class, 'assignedto', 'id');
+        return  $this->belongsTo(User::class, 'assignedto', 'id');
         
     }
     public function comments()
 	{
-        return  $this->hasMany(projectupdates::class, 'taskid', 'id');
+        return  $this->hasMany(ProjectUpdates::class, 'taskid', 'id');
         
     }
 }

--- a/app/Models/ProjectUpdate.php
+++ b/app/Models/ProjectUpdate.php
@@ -5,12 +5,13 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-class Notifications extends Model
+class ProjectUpdate extends Model
 {
     use HasFactory;
-    public function added()
+
+    public function addedby()
 	{
-        return  $this->belongsTo(User::class, 'fromid', 'id');
+        return  $this->belongsTo(User::class, 'auth', 'id');
         
     }
 }

--- a/app/Models/ProjectUpdates.php
+++ b/app/Models/ProjectUpdates.php
@@ -5,14 +5,13 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-class expensemanager extends Model
+class ProjectUpdates extends Model
 {
     use HasFactory;
 
-    public function projectdata()
+    public function addedby()
 	{
-        return  $this->belongsto(project::class, 'prid', 'id');
+        return  $this->belongsTo(User::class, 'auth', 'id');
         
     }
-
 }

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -5,7 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-class Invoicemeta extends Model
+class Setting extends Model
 {
     use HasFactory;
 }

--- a/app/Models/TaskTodo.php
+++ b/app/Models/TaskTodo.php
@@ -5,7 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-class TaskTodos extends Model
+class TaskTodo extends Model
 {
     use HasFactory;
 

--- a/app/Models/TaskTodos.php
+++ b/app/Models/TaskTodos.php
@@ -5,7 +5,13 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-class client extends Model
+class TaskTodos extends Model
 {
     use HasFactory;
+
+    public function added()
+	{
+        return  $this->belongsTo(User::class, 'auth', 'id');
+        
+    }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,8 +4,8 @@ namespace App\Providers;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Database\Connection;
-use App\Models\setting;
-use App\Models\notifications;
+use App\Models\Setting;
+use App\Models\Notifications;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\DB;
@@ -32,7 +32,7 @@ class AppServiceProvider extends ServiceProvider
 
           if(env('DB_USERNAME')!=NULL){
             if (Schema::hasTable('settings')) {
-                    $setings = setting::first();
+                    $setings = Setting::first();
                    
                     View::share(['settings' =>$setings]);   
                 }                            

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,7 +5,7 @@ use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Database\Connection;
 use App\Models\Setting;
-use App\Models\Notifications;
+use App\Models\Notification;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\DB;

--- a/database/migrations/2023_10_23_073523_rename_payment_recepits_table.php
+++ b/database/migrations/2023_10_23_073523_rename_payment_recepits_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class RenamePaymentRecepitsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::rename(
+            'paymentrecepits',
+            'payment_receipts'
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::rename(
+            'payment_receipts',
+            'paymentrecepits'
+        );
+    }
+}

--- a/database/migrations/2023_10_23_073710_rename_expensemanager_table.php
+++ b/database/migrations/2023_10_23_073710_rename_expensemanager_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class RenameExpensemanagerTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::rename(
+            'expensemanagers',
+            'expense_managers'
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::rename(
+            'expense_managers',
+            'expensemanagers'
+        );
+    }
+}

--- a/database/migrations/2023_10_23_073800_rename_projecttasks_table.php
+++ b/database/migrations/2023_10_23_073800_rename_projecttasks_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class RenameProjecttasksTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::rename(
+            'projecttasks',
+            'project_tasks'
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::rename(
+            'project_tasks',
+            'projecttasks'
+        );
+    }
+}

--- a/database/migrations/2023_10_23_073944_rename_paymentgateways_table.php
+++ b/database/migrations/2023_10_23_073944_rename_paymentgateways_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class RenamePaymentgatewaysTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::rename(
+            'paymentgateways',
+            'payment_gateways'
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::rename(
+            'payment_gateways',
+            'paymentgateways'
+        );
+    }
+}

--- a/database/migrations/2023_10_23_074051_rename_projectnotes_table.php
+++ b/database/migrations/2023_10_23_074051_rename_projectnotes_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class RenameProjectnotesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::rename(
+            'projectnotes',
+            'project_notes'
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::rename(
+            'project_notes',
+            'projectnotes'
+        );
+    }
+}

--- a/database/migrations/2023_10_23_074143_rename_invoicemetas_table.php
+++ b/database/migrations/2023_10_23_074143_rename_invoicemetas_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class RenameInvoicemetasTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::rename(
+            'invoicemetas',
+            'invoice_metas'
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::rename(
+            'invoice_metas',
+            'invoicemetas'
+        );
+    }
+}

--- a/database/migrations/2023_10_23_074205_rename_tasktodos_table.php
+++ b/database/migrations/2023_10_23_074205_rename_tasktodos_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class RenameTasktodosTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::rename(
+            'tasktodos',
+            'task_todos'
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::rename(
+            'task_todos',
+            'tasktodos'
+        );
+    }
+}

--- a/database/migrations/2023_10_23_074325_rename_projectupdates_table.php
+++ b/database/migrations/2023_10_23_074325_rename_projectupdates_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class RenameProjectupdatesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::rename(
+            'projectupdates',
+            'project_updates'
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::rename(
+            'project_updates',
+            'projectupdates'
+        );
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -15,7 +15,7 @@ class DatabaseSeeder extends Seeder
     {
         
         $this->call([
-            gatewayseeder::class,           
+            GatewaySeeder::class,
         ]);
         // \App\Models\User::factory(10)->create();
     }

--- a/database/seeders/GatewaySeeder.php
+++ b/database/seeders/GatewaySeeder.php
@@ -5,7 +5,7 @@ namespace Database\Seeders;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
 
-class gatewayseeder extends Seeder
+class GatewaySeeder extends Seeder
 {
     /**
      * Run the database seeds.

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,8 +5,8 @@ use App\Http\Controllers\AdminController;
 use App\Http\Controllers\SettingsController;
 use App\Http\Controllers\ClientController;
 use App\Http\Controllers\InvoiceController;
-use App\Http\Controllers\gatewaycontroller;
-use App\Http\Controllers\projectcontroller;
+use App\Http\Controllers\GatewayController;
+use App\Http\Controllers\ProjectController;
 
 
 /*
@@ -36,9 +36,9 @@ Route::get('/quote/public/{id}', [InvoiceController::class, 'viewquotepublic'])-
 Route::get('/quote/stat/public/{id}/{stat}', [InvoiceController::class, 'quotestatuschangepublic'])->name('quotestatuschangepublic');
 
 
-Route::post('/invoices/capture/razorpaypayment', [gatewaycontroller::class, 'razorpaypayment'])->name('razorpaypayment');
-Route::post('/invoices/capture/stripe', [gatewaycontroller::class, 'stripepayment'])->name('stripepayment');
-Route::post('/invoices/capture/paypal', [gatewaycontroller::class, 'paypalhandlePayment'])->name('paypalhandlePayment');
+Route::post('/invoices/capture/razorpaypayment', [GatewayController::class, 'razorpaypayment'])->name('razorpaypayment');
+Route::post('/invoices/capture/stripe', [GatewayController::class, 'stripepayment'])->name('stripepayment');
+Route::post('/invoices/capture/paypal', [GatewayController::class, 'paypalhandlePayment'])->name('paypalhandlePayment');
 
 
 
@@ -88,42 +88,42 @@ Route::group(['middleware' => ['auth']], function(){
     Route::get('/expenses', [InvoiceController::class, 'expensemanagerlist'])->name('expensemanagerlist');
     Route::post('/expenses/new/save', [InvoiceController::class, 'createnewexpense'])->name('createnewexpense');
     Route::post('/expenses/edit/save', [InvoiceController::class, 'editexpense'])->name('editexpense');
-    Route::get('/project/expenses/{id}', [projectcontroller::class, 'viewprojectexpense'])->name('viewprojectexpense');
-    Route::get('/expenses/delete/{id}', [projectcontroller::class, 'deleteexpense'])->name('deleteexpense');
+    Route::get('/project/expenses/{id}', [ProjectController::class, 'viewprojectexpense'])->name('viewprojectexpense');
+    Route::get('/expenses/delete/{id}', [ProjectController::class, 'deleteexpense'])->name('deleteexpense');
 
     Route::get('/cashbook', [InvoiceController::class, 'cashbooklist'])->name('cashbooklist');
     
 
-    Route::get('/mytasks', [projectcontroller::class, 'mytasks'])->name('mytasks');
-    Route::get('/mytasks/view/{id}', [projectcontroller::class, 'viewtask'])->name('viewtask');
-    Route::post('/mytasks/task/addtodo', [projectcontroller::class, 'addtasktodo'])->name('addtasktodo');
-    Route::post('/mytasks/task/addtodo/update', [projectcontroller::class, 'todostatusupdate'])->name('todostatusupdate');
-    Route::get('/mytasks/task/todo/delete/{id}', [projectcontroller::class, 'tasktododelete'])->name('tasktododelete');
-    Route::post('/mytasks/task/addcomment', [projectcontroller::class, 'addtaskcomment'])->name('addtaskcomment');
-    Route::get('/mytasks/view/complete/{id}', [projectcontroller::class, 'taskcomplete'])->name('taskcomplete');
+    Route::get('/mytasks', [ProjectController::class, 'mytasks'])->name('mytasks');
+    Route::get('/mytasks/view/{id}', [ProjectController::class, 'viewtask'])->name('viewtask');
+    Route::post('/mytasks/task/addtodo', [ProjectController::class, 'addtasktodo'])->name('addtasktodo');
+    Route::post('/mytasks/task/addtodo/update', [ProjectController::class, 'todostatusupdate'])->name('todostatusupdate');
+    Route::get('/mytasks/task/todo/delete/{id}', [ProjectController::class, 'tasktododelete'])->name('tasktododelete');
+    Route::post('/mytasks/task/addcomment', [ProjectController::class, 'addtaskcomment'])->name('addtaskcomment');
+    Route::get('/mytasks/view/complete/{id}', [ProjectController::class, 'taskcomplete'])->name('taskcomplete');
 
-    Route::get('/notification/update/{id}', [projectcontroller::class, 'notificationupdate'])->name('notificationupdate');
+    Route::get('/notification/update/{id}', [ProjectController::class, 'notificationupdate'])->name('notificationupdate');
  
 
     Route::get('/filemanager', [InvoiceController::class, 'filemanager'])->name('filemanager');
     
-    Route::get('/projects', [projectcontroller::class, 'listofprojects'])->name('listofprojects');
-    Route::post('/projects/new/save', [projectcontroller::class, 'createnewproject'])->name('createnewproject');
-    Route::post('/projects/update/save', [projectcontroller::class, 'updateproject'])->name('updateproject');
-    Route::post('/projects/descrip/save', [projectcontroller::class, 'updateprojectdescript'])->name('updateprojectdescript');
-    Route::post('/projects/status/change', [projectcontroller::class, 'projectstatuschange'])->name('projectstatuschange');
-    Route::get('/project/{id}', [projectcontroller::class, 'viewproject'])->name('viewproject');
-    Route::get('/project/delete/{id}', [projectcontroller::class, 'deleteproject'])->name('deleteproject');
-    Route::get('/project/tasks/{id}', [projectcontroller::class, 'viewtasks'])->name('viewtasksprjct');
-    Route::post('/project/tasks/save', [projectcontroller::class, 'createprjcttask'])->name('createprjcttask');
-    Route::post('/project/tasks/update', [projectcontroller::class, 'projecttaskupdate'])->name('projecttaskupdate');
-    Route::get('/project/tasks/delete/{id}', [projectcontroller::class, 'deletetasks'])->name('deletetasks');
-    Route::get('/project/note/{id}', [projectcontroller::class, 'viewnote'])->name('viewnoteprjct');
-    Route::post('/project/note/save', [projectcontroller::class, 'updatenote'])->name('updatenoteprjct');
-    Route::post('/projects/updates/new', [projectcontroller::class, 'addprojectupdates'])->name('addprojectupdates');
-    Route::post('/projects/updates/edit', [projectcontroller::class, 'editprojectupdates'])->name('editprojectupdates');
+    Route::get('/projects', [ProjectController::class, 'listofprojects'])->name('listofprojects');
+    Route::post('/projects/new/save', [ProjectController::class, 'createnewproject'])->name('createnewproject');
+    Route::post('/projects/update/save', [ProjectController::class, 'updateproject'])->name('updateproject');
+    Route::post('/projects/descrip/save', [ProjectController::class, 'updateprojectdescript'])->name('updateprojectdescript');
+    Route::post('/projects/status/change', [ProjectController::class, 'projectstatuschange'])->name('projectstatuschange');
+    Route::get('/project/{id}', [ProjectController::class, 'viewproject'])->name('viewproject');
+    Route::get('/project/delete/{id}', [ProjectController::class, 'deleteproject'])->name('deleteproject');
+    Route::get('/project/tasks/{id}', [ProjectController::class, 'viewtasks'])->name('viewtasksprjct');
+    Route::post('/project/tasks/save', [ProjectController::class, 'createprjcttask'])->name('createprjcttask');
+    Route::post('/project/tasks/update', [ProjectController::class, 'projecttaskupdate'])->name('projecttaskupdate');
+    Route::get('/project/tasks/delete/{id}', [ProjectController::class, 'deletetasks'])->name('deletetasks');
+    Route::get('/project/note/{id}', [ProjectController::class, 'viewnote'])->name('viewnoteprjct');
+    Route::post('/project/note/save', [ProjectController::class, 'updatenote'])->name('updatenoteprjct');
+    Route::post('/projects/updates/new', [ProjectController::class, 'addprojectupdates'])->name('addprojectupdates');
+    Route::post('/projects/updates/edit', [ProjectController::class, 'editprojectupdates'])->name('editprojectupdates');
     
-    Route::get('/project/deleteupdates/{id}', [projectcontroller::class, 'deleteupdates'])->name('deleteupdates');
+    Route::get('/project/deleteupdates/{id}', [ProjectController::class, 'deleteupdates'])->name('deleteupdates');
     
     
 
@@ -150,9 +150,9 @@ Route::group(['middleware' => ['auth','admin']], function(){
     Route::post('/admin/settings/invoice/save', [SettingsController::class, 'invoicesettingssave'])->name('invoicesettingssave');
 
 
-    Route::get('/admin/settings/paymentgateway', [gatewaycontroller::class, 'paymentgatewaysettings'])->name('paymentgatewaysettings');
-    Route::post('/admin/settings/paymentgateway/save', [gatewaycontroller::class, 'paymentgatewaysettingssave'])->name('paymentgatewaysettingssave');
-    Route::post('/admin/settings/paymentgateway/enable', [gatewaycontroller::class, 'paymentgatewayenable'])->name('paymentgatewayenable');
+    Route::get('/admin/settings/paymentgateway', [GatewayController::class, 'paymentgatewaysettings'])->name('paymentgatewaysettings');
+    Route::post('/admin/settings/paymentgateway/save', [GatewayController::class, 'paymentgatewaysettingssave'])->name('paymentgatewaysettingssave');
+    Route::post('/admin/settings/paymentgateway/enable', [GatewayController::class, 'paymentgatewayenable'])->name('paymentgatewayenable');
     
     Route::get('/admin/settings/business', [SettingsController::class, 'businesssetting'])->name('businesssetting');
     Route::post('/admin/settings/business/save', [SettingsController::class, 'businesssettingsave'])->name('businesssettingsave');


### PR DESCRIPTION
It's just a first step but I used the normal Laravel / PHP convention for class names (camel case and singular). Also I fixed a name typo: it is not "payment recepit" but "payment receipt".