### PR TITLE
Feature: icon components

### DIFF
--- a/resources/views/app/projectnav.blade.php
+++ b/resources/views/app/projectnav.blade.php
@@ -1,23 +1,19 @@
- <div class="dropdown-menu dropdown-menu-demo ">
-            <span class="dropdown-header">Menu</span>
-            <a class="dropdown-item " href="/project/{{$prid}}">                  
-            <svg xmlns="http://www.w3.org/2000/svg" style="margin-right: 10px;" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M14 3v4a1 1 0 0 0 1 1h4" /><path d="M17 21h-10a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h7l5 5v11a2 2 0 0 1 -2 2z" /><line x1="9" y1="7" x2="10" y2="7" /><line x1="9" y1="13" x2="15" y2="13" /><line x1="13" y1="17" x2="15" y2="17" /></svg>
-                Overview
-            </a>
-          
-            <a class="dropdown-item " href="/project/tasks/{{$prid}}" >            
-              <svg xmlns="http://www.w3.org/2000/svg" class="icon" style="margin-right: 10px;"  width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M11 7h-5a2 2 0 0 0 -2 2v9a2 2 0 0 0 2 2h9a2 2 0 0 0 2 -2v-5" /><line x1="10" y1="14" x2="20" y2="4" /><polyline points="15 4 20 4 20 9" /></svg>
-                  Tasks
-            </a>
-            <a class="dropdown-item " href="/project/note/{{$prid}}" >            
-              <svg xmlns="http://www.w3.org/2000/svg" class="icon" style="margin-right: 10px;"  width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><circle cx="12" cy="12" r="4" /><path d="M16 12v1.5a2.5 2.5 0 0 0 5 0v-1.5a9 9 0 1 0 -5.5 8.28" /></svg>
-                  Notes
-                </a>
-
-                <a class="dropdown-item " href="/project/expenses/{{$prid}}" >            
-                  <x-icon.expense style="margin-right: 10px;" />
-                      Expenses
-                 </a>                
-                
-
-        </div>
+<div class="dropdown-menu dropdown-menu-demo">
+  <span class="dropdown-header">Menu</span>
+  <a class="dropdown-item" href="/project/{{$prid}}">
+    <x-icon.invoice style="margin-right: 10px;" />
+    <span>Overview</span>
+  </a>
+  <a class="dropdown-item" href="/project/tasks/{{$prid}}" >
+    <x-icon.task style="margin-right: 10px;" />
+    <span>Tasks</span>
+  </a>
+  <a class="dropdown-item" href="/project/note/{{$prid}}" >
+    <x-icon.note style="margin-right: 10px;" />
+    <span>Notes</span>
+  </a>
+  <a class="dropdown-item" href="/project/expenses/{{$prid}}">
+    <x-icon.expense style="margin-right: 10px;" />
+    <span>Expenses</span>
+  </a>
+</div>

--- a/resources/views/app/projectnav.blade.php
+++ b/resources/views/app/projectnav.blade.php
@@ -15,7 +15,7 @@
                 </a>
 
                 <a class="dropdown-item " href="/project/expenses/{{$prid}}" >            
-                  <x-icon.expense />
+                  <x-icon.expense style="margin-right: 10px;" />
                       Expenses
                  </a>                
                 

--- a/resources/views/app/projectnav.blade.php
+++ b/resources/views/app/projectnav.blade.php
@@ -15,7 +15,7 @@
                 </a>
 
                 <a class="dropdown-item " href="/project/expenses/{{$prid}}" >            
-                  <svg xmlns="http://www.w3.org/2000/svg" class="icon" style="margin-right: 10px;"  width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><circle cx="12" cy="12" r="4" /><path d="M16 12v1.5a2.5 2.5 0 0 0 5 0v-1.5a9 9 0 1 0 -5.5 8.28" /></svg>
+                  <x-icon.expense />
                       Expenses
                  </a>                
                 

--- a/resources/views/app/projectview.blade.php
+++ b/resources/views/app/projectview.blade.php
@@ -14,17 +14,17 @@
 
             <a class="dropdown-item " href="#timeline"  data-toggle="modal" data-target="#modal-simple"   >       
            
-              <x-icon.invoice />
+              <x-icon.invoice style="margin-right: 10px;" />
                              Invoice Project
                         </a>
            
             <a class="dropdown-item " href="#timeline"  data-toggle="modal" data-target="#editproject">       
-              <x-icon.edit />
+              <x-icon.edit style="margin-right: 10px;" />
                  Edit Project
             </a>
 
             <a class="dropdown-item " href="/project/delete/{{$prid}}" onclick="return confirm('Are you sure?')" >
-              <x-icon.delete />
+              <x-icon.delete style="margin-right: 10px;" />
                    Delete Project
               </a>
           

--- a/resources/views/app/projectview.blade.php
+++ b/resources/views/app/projectview.blade.php
@@ -12,23 +12,20 @@
         <div class="dropdown-menu dropdown-menu-demo ">
             <span class="dropdown-header">Project</span>
 
-            <a class="dropdown-item " href="#timeline"  data-toggle="modal" data-target="#modal-simple"   >       
-           
+            <a class="dropdown-item" href="#timeline"  data-toggle="modal" data-target="#modal-simple">
               <x-icon.invoice style="margin-right: 10px;" />
-                             Invoice Project
-                        </a>
+              <span>Invoice Project</span>
+            </a>
            
-            <a class="dropdown-item " href="#timeline"  data-toggle="modal" data-target="#editproject">       
+            <a class="dropdown-item" href="#timeline"  data-toggle="modal" data-target="#editproject">
               <x-icon.edit style="margin-right: 10px;" />
-                 Edit Project
+              <span>Edit Project</span>
             </a>
 
-            <a class="dropdown-item " href="/project/delete/{{$prid}}" onclick="return confirm('Are you sure?')" >
+            <a class="dropdown-item" href="/project/delete/{{$prid}}" onclick="return confirm('Are you sure?')">
               <x-icon.delete style="margin-right: 10px;" />
-                   Delete Project
-              </a>
-          
-
+              <span>Delete Project</span>
+            </a>
         </div>
 
         <br> <br>

--- a/resources/views/app/projectview.blade.php
+++ b/resources/views/app/projectview.blade.php
@@ -14,27 +14,17 @@
 
             <a class="dropdown-item " href="#timeline"  data-toggle="modal" data-target="#modal-simple"   >       
            
-              <svg xmlns="http://www.w3.org/2000/svg" style="margin-right: 10px;" class="icon icon-tabler icon-tabler-file-invoice" width="32" height="32" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
-               
-                <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-                <path d="M14 3v4a1 1 0 0 0 1 1h4"></path>
-                <path d="M17 21h-10a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h7l5 5v11a2 2 0 0 1 -2 2z"></path>
-                <line x1="9" y1="7" x2="10" y2="7"></line>
-                <line x1="9" y1="13" x2="15" y2="13"></line>
-                <line x1="13" y1="17" x2="15" y2="17"></line>
-             </svg>
+              <x-icon.invoice />
                              Invoice Project
                         </a>
            
             <a class="dropdown-item " href="#timeline"  data-toggle="modal" data-target="#editproject">       
-           
-	<svg xmlns="http://www.w3.org/2000/svg" class="icon" style="margin-right: 10px;" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M9 7h-3a2 2 0 0 0 -2 2v9a2 2 0 0 0 2 2h9a2 2 0 0 0 2 -2v-3" /><path d="M9 15h3l8.5 -8.5a1.5 1.5 0 0 0 -3 -3l-8.5 8.5v3" /><line x1="16" y1="5" x2="19" y2="8" /></svg>
+              <x-icon.edit />
                  Edit Project
             </a>
 
-            <a class="dropdown-item " href="/project/delete/{{$prid}}" onclick="return confirm('Are you sure?')" >                  
-            
-	<svg xmlns="http://www.w3.org/2000/svg" class="icon" style="margin-right: 10px;" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><line x1="4" y1="7" x2="20" y2="7" /><line x1="10" y1="11" x2="10" y2="17" /><line x1="14" y1="11" x2="14" y2="17" /><path d="M5 7l1 12a2 2 0 0 0 2 2h8a2 2 0 0 0 2 -2l1 -12" /><path d="M9 7v-3a1 1 0 0 1 1 -1h4a1 1 0 0 1 1 1v3" /></svg>
+            <a class="dropdown-item " href="/project/delete/{{$prid}}" onclick="return confirm('Are you sure?')" >
+              <x-icon.delete />
                    Delete Project
               </a>
           

--- a/resources/views/components/icon/admin-panel.blade.php
+++ b/resources/views/components/icon/admin-panel.blade.php
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" {{ $attributes->merge(['class' => 'icon']) }}>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" role="none" {{ $attributes->merge(['class' => 'icon']) }}>
   <path stroke="none" d="M0 0h24v24H0z" />
   <polyline points="12 3 20 7.5 20 16.5 12 21 4 16.5 4 7.5 12 3" />
   <line x1="12" y1="12" x2="20" y2="7.5" />

--- a/resources/views/components/icon/admin-panel.blade.php
+++ b/resources/views/components/icon/admin-panel.blade.php
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path stroke="none" d="M0 0h24v24H0z" />
+    <polyline points="12 3 20 7.5 20 16.5 12 21 4 16.5 4 7.5 12 3" />
+    <line x1="12" y1="12" x2="20" y2="7.5" />
+    <line x1="12" y1="12" x2="12" y2="21" />
+    <line x1="12" y1="12" x2="4" y2="7.5" />
+    <line x1="16" y1="5.25" x2="8" y2="9.75" />
+</svg>

--- a/resources/views/components/icon/admin-panel.blade.php
+++ b/resources/views/components/icon/admin-panel.blade.php
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" {{ $attributes->merge(['class' => 'icon']) }}>
-    <path stroke="none" d="M0 0h24v24H0z" />
-    <polyline points="12 3 20 7.5 20 16.5 12 21 4 16.5 4 7.5 12 3" />
-    <line x1="12" y1="12" x2="20" y2="7.5" />
-    <line x1="12" y1="12" x2="12" y2="21" />
-    <line x1="12" y1="12" x2="4" y2="7.5" />
-    <line x1="16" y1="5.25" x2="8" y2="9.75" />
+  <path stroke="none" d="M0 0h24v24H0z" />
+  <polyline points="12 3 20 7.5 20 16.5 12 21 4 16.5 4 7.5 12 3" />
+  <line x1="12" y1="12" x2="20" y2="7.5" />
+  <line x1="12" y1="12" x2="12" y2="21" />
+  <line x1="12" y1="12" x2="4" y2="7.5" />
+  <line x1="16" y1="5.25" x2="8" y2="9.75" />
 </svg>

--- a/resources/views/components/icon/admin-panel.blade.php
+++ b/resources/views/components/icon/admin-panel.blade.php
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" {{ $attributes->merge(['class' => 'icon']) }}>
     <path stroke="none" d="M0 0h24v24H0z" />
     <polyline points="12 3 20 7.5 20 16.5 12 21 4 16.5 4 7.5 12 3" />
     <line x1="12" y1="12" x2="20" y2="7.5" />

--- a/resources/views/components/icon/client.blade.php
+++ b/resources/views/components/icon/client.blade.php
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" {{ $attributes->merge(['class' => 'icon']) }}>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" role="none" {{ $attributes->merge(['class' => 'icon']) }}>
   <path stroke="none" d="M0 0h24v24H0z" fill="none" />
   <circle cx="9" cy="7" r="4" />
   <path d="M3 21v-2a4 4 0 0 1 4 -4h4a4 4 0 0 1 4 4v2" />

--- a/resources/views/components/icon/client.blade.php
+++ b/resources/views/components/icon/client.blade.php
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+  <circle cx="9" cy="7" r="4" />
+  <path d="M3 21v-2a4 4 0 0 1 4 -4h4a4 4 0 0 1 4 4v2" />
+  <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+  <path d="M21 21v-2a4 4 0 0 0 -3 -3.85" />
+</svg>

--- a/resources/views/components/icon/client.blade.php
+++ b/resources/views/components/icon/client.blade.php
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" {{ $attributes->merge(['class' => 'icon']) }}>
   <path stroke="none" d="M0 0h24v24H0z" fill="none" />
   <circle cx="9" cy="7" r="4" />
   <path d="M3 21v-2a4 4 0 0 1 4 -4h4a4 4 0 0 1 4 4v2" />

--- a/resources/views/components/icon/dashboard.blade.php
+++ b/resources/views/components/icon/dashboard.blade.php
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" {{ $attributes->merge(['class' => 'icon']) }}>
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" role="none" {{ $attributes->merge(['class' => 'icon']) }}>
   <path stroke="none" d="M0 0h24v24H0z" fill="none" />
   <circle cx="12" cy="13" r="2" />
   <line x1="13.45" y1="11.55" x2="15.5" y2="9.5" />

--- a/resources/views/components/icon/dashboard.blade.php
+++ b/resources/views/components/icon/dashboard.blade.php
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-dashboard" width="32" height="32" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+  <circle cx="12" cy="13" r="2" />
+  <line x1="13.45" y1="11.55" x2="15.5" y2="9.5" />
+  <path d="M6.4 20a9 9 0 1 1 11.2 0z" />
+</svg>

--- a/resources/views/components/icon/dashboard.blade.php
+++ b/resources/views/components/icon/dashboard.blade.php
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-dashboard" width="32" height="32" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" {{ $attributes->merge(['class' => 'icon']) }}>
   <path stroke="none" d="M0 0h24v24H0z" fill="none" />
   <circle cx="12" cy="13" r="2" />
   <line x1="13.45" y1="11.55" x2="15.5" y2="9.5" />

--- a/resources/views/components/icon/delete.blade.php
+++ b/resources/views/components/icon/delete.blade.php
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" {{ $attributes->merge(['class' => 'icon']) }}>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" role="none" {{ $attributes->merge(['class' => 'icon']) }}>
   <path stroke="none" d="M0 0h24v24H0z" fill="none" />
   <line x1="4" y1="7" x2="20" y2="7" />
   <line x1="10" y1="11" x2="10" y2="17" />

--- a/resources/views/components/icon/delete.blade.php
+++ b/resources/views/components/icon/delete.blade.php
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" class="icon" style="margin-right: 10px;" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" {{ $attributes->merge(['class' => 'icon']) }}>
   <path stroke="none" d="M0 0h24v24H0z" fill="none" />
   <line x1="4" y1="7" x2="20" y2="7" />
   <line x1="10" y1="11" x2="10" y2="17" />

--- a/resources/views/components/icon/delete.blade.php
+++ b/resources/views/components/icon/delete.blade.php
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon" style="margin-right: 10px;" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+  <line x1="4" y1="7" x2="20" y2="7" />
+  <line x1="10" y1="11" x2="10" y2="17" />
+  <line x1="14" y1="11" x2="14" y2="17" />
+  <path d="M5 7l1 12a2 2 0 0 0 2 2h8a2 2 0 0 0 2 -2l1 -12" />
+  <path d="M9 7v-3a1 1 0 0 1 1 -1h4a1 1 0 0 1 1 1v3" />
+</svg>

--- a/resources/views/components/icon/edit.blade.php
+++ b/resources/views/components/icon/edit.blade.php
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon" style="margin-right: 10px;" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+  <path d="M9 7h-3a2 2 0 0 0 -2 2v9a2 2 0 0 0 2 2h9a2 2 0 0 0 2 -2v-3" />
+  <path d="M9 15h3l8.5 -8.5a1.5 1.5 0 0 0 -3 -3l-8.5 8.5v3" />
+  <line x1="16" y1="5" x2="19" y2="8" />
+</svg>

--- a/resources/views/components/icon/edit.blade.php
+++ b/resources/views/components/icon/edit.blade.php
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" class="icon" style="margin-right: 10px;" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" {{ $attributes->merge(['class' => 'icon']) }}>
   <path stroke="none" d="M0 0h24v24H0z" fill="none" />
   <path d="M9 7h-3a2 2 0 0 0 -2 2v9a2 2 0 0 0 2 2h9a2 2 0 0 0 2 -2v-3" />
   <path d="M9 15h3l8.5 -8.5a1.5 1.5 0 0 0 -3 -3l-8.5 8.5v3" />

--- a/resources/views/components/icon/edit.blade.php
+++ b/resources/views/components/icon/edit.blade.php
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" {{ $attributes->merge(['class' => 'icon']) }}>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" role="none" {{ $attributes->merge(['class' => 'icon']) }}>
   <path stroke="none" d="M0 0h24v24H0z" fill="none" />
   <path d="M9 7h-3a2 2 0 0 0 -2 2v9a2 2 0 0 0 2 2h9a2 2 0 0 0 2 -2v-3" />
   <path d="M9 15h3l8.5 -8.5a1.5 1.5 0 0 0 -3 -3l-8.5 8.5v3" />

--- a/resources/views/components/icon/expense.blade.php
+++ b/resources/views/components/icon/expense.blade.php
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" {{ $attributes->merge(['class' => 'icon']) }} width="32" height="32" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" {{ $attributes->merge(['class' => 'icon']) }}>
   <path stroke="none" d="M0 0h24v24H0z" fill="none" />
   <path d="M17 8v-3a1 1 0 0 0 -1 -1h-10a2 2 0 0 0 0 4h12a1 1 0 0 1 1 1v3m0 4v3a1 1 0 0 1 -1 1h-12a2 2 0 0 1 -2 -2v-12" />
   <path d="M20 12v4h-4a2 2 0 0 1 0 -4h4" />

--- a/resources/views/components/icon/expense.blade.php
+++ b/resources/views/components/icon/expense.blade.php
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" {{ $attributes->merge(['class' => 'icon']) }} width="32" height="32" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+  <path d="M17 8v-3a1 1 0 0 0 -1 -1h-10a2 2 0 0 0 0 4h12a1 1 0 0 1 1 1v3m0 4v3a1 1 0 0 1 -1 1h-12a2 2 0 0 1 -2 -2v-12" />
+  <path d="M20 12v4h-4a2 2 0 0 1 0 -4h4" />
+</svg>

--- a/resources/views/components/icon/expense.blade.php
+++ b/resources/views/components/icon/expense.blade.php
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" {{ $attributes->merge(['class' => 'icon']) }}>
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" role="none" {{ $attributes->merge(['class' => 'icon']) }}>
   <path stroke="none" d="M0 0h24v24H0z" fill="none" />
   <path d="M17 8v-3a1 1 0 0 0 -1 -1h-10a2 2 0 0 0 0 4h12a1 1 0 0 1 1 1v3m0 4v3a1 1 0 0 1 -1 1h-12a2 2 0 0 1 -2 -2v-12" />
   <path d="M20 12v4h-4a2 2 0 0 1 0 -4h4" />

--- a/resources/views/components/icon/file-manager.blade.php
+++ b/resources/views/components/icon/file-manager.blade.php
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-cloud-upload" width="32" height="32" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" {{ $attributes->merge(['class' => 'icon']) }}>
   <path stroke="none" d="M0 0h24v24H0z" fill="none" />
   <path d="M7 18a4.6 4.4 0 0 1 0 -9a5 4.5 0 0 1 11 2h1a3.5 3.5 0 0 1 0 7h-1" />
   <polyline points="9 15 12 12 15 15" />

--- a/resources/views/components/icon/file-manager.blade.php
+++ b/resources/views/components/icon/file-manager.blade.php
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-cloud-upload" width="32" height="32" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+  <path d="M7 18a4.6 4.4 0 0 1 0 -9a5 4.5 0 0 1 11 2h1a3.5 3.5 0 0 1 0 7h-1" />
+  <polyline points="9 15 12 12 15 15" />
+  <line x1="12" y1="12" x2="12" y2="21" />
+</svg>

--- a/resources/views/components/icon/file-manager.blade.php
+++ b/resources/views/components/icon/file-manager.blade.php
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" {{ $attributes->merge(['class' => 'icon']) }}>
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" role="none" {{ $attributes->merge(['class' => 'icon']) }}>
   <path stroke="none" d="M0 0h24v24H0z" fill="none" />
   <path d="M7 18a4.6 4.4 0 0 1 0 -9a5 4.5 0 0 1 11 2h1a3.5 3.5 0 0 1 0 7h-1" />
   <polyline points="9 15 12 12 15 15" />

--- a/resources/views/components/icon/invoice.blade.php
+++ b/resources/views/components/icon/invoice.blade.php
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+  <path d="M14 3v4a1 1 0 0 0 1 1h4" />
+  <path d="M17 21h-10a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h7l5 5v11a2 2 0 0 1 -2 2z" />
+  <line x1="9" y1="7" x2="10" y2="7" />
+  <line x1="9" y1="13" x2="15" y2="13" />
+  <line x1="13" y1="17" x2="15" y2="17" />
+</svg>

--- a/resources/views/components/icon/invoice.blade.php
+++ b/resources/views/components/icon/invoice.blade.php
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" {{ $attributes->merge(['class' => 'icon']) }}>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" role="none" {{ $attributes->merge(['class' => 'icon']) }}>
   <path stroke="none" d="M0 0h24v24H0z" fill="none" />
   <path d="M14 3v4a1 1 0 0 0 1 1h4" />
   <path d="M17 21h-10a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h7l5 5v11a2 2 0 0 1 -2 2z" />

--- a/resources/views/components/icon/invoice.blade.php
+++ b/resources/views/components/icon/invoice.blade.php
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" {{ $attributes->merge(['class' => 'icon']) }}>
   <path stroke="none" d="M0 0h24v24H0z" fill="none" />
   <path d="M14 3v4a1 1 0 0 0 1 1h4" />
   <path d="M17 21h-10a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h7l5 5v11a2 2 0 0 1 -2 2z" />

--- a/resources/views/components/icon/note.blade.php
+++ b/resources/views/components/icon/note.blade.php
@@ -1,6 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" {{ $attributes->merge(['class' => 'icon']) }}>
   <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-  <path d="M11 7h-5a2 2 0 0 0 -2 2v9a2 2 0 0 0 2 2h9a2 2 0 0 0 2 -2v-5" />
-  <line x1="10" y1="14" x2="20" y2="4" />
-  <polyline points="15 4 20 4 20 9" />
+  <circle cx="12" cy="12" r="4" />
+  <path d="M16 12v1.5a2.5 2.5 0 0 0 5 0v-1.5a9 9 0 1 0 -5.5 8.28" />
 </svg>

--- a/resources/views/components/icon/note.blade.php
+++ b/resources/views/components/icon/note.blade.php
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" {{ $attributes->merge(['class' => 'icon']) }}>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" role="none" {{ $attributes->merge(['class' => 'icon']) }}>
   <path stroke="none" d="M0 0h24v24H0z" fill="none" />
   <circle cx="12" cy="12" r="4" />
   <path d="M16 12v1.5a2.5 2.5 0 0 0 5 0v-1.5a9 9 0 1 0 -5.5 8.28" />

--- a/resources/views/components/icon/offer.blade.php
+++ b/resources/views/components/icon/offer.blade.php
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+  <rect x="3" y="7" width="18" height="13" rx="2" />
+  <path d="M8 7v-2a2 2 0 0 1 2 -2h4a2 2 0 0 1 2 2v2" />
+  <line x1="12" y1="12" x2="12" y2="12.01" />
+  <path d="M3 13a20 20 0 0 0 18 0" />
+</svg>

--- a/resources/views/components/icon/offer.blade.php
+++ b/resources/views/components/icon/offer.blade.php
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" {{ $attributes->merge(['class' => 'icon']) }}>
   <path stroke="none" d="M0 0h24v24H0z" fill="none" />
   <rect x="3" y="7" width="18" height="13" rx="2" />
   <path d="M8 7v-2a2 2 0 0 1 2 -2h4a2 2 0 0 1 2 2v2" />

--- a/resources/views/components/icon/offer.blade.php
+++ b/resources/views/components/icon/offer.blade.php
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" {{ $attributes->merge(['class' => 'icon']) }}>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" role="none" {{ $attributes->merge(['class' => 'icon']) }}>
   <path stroke="none" d="M0 0h24v24H0z" fill="none" />
   <rect x="3" y="7" width="18" height="13" rx="2" />
   <path d="M8 7v-2a2 2 0 0 1 2 -2h4a2 2 0 0 1 2 2v2" />

--- a/resources/views/components/icon/paid-invoice.blade.php
+++ b/resources/views/components/icon/paid-invoice.blade.php
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" {{ $attributes->merge(['class' => 'icon']) }}>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" role="none" {{ $attributes->merge(['class' => 'icon']) }}>
   <path stroke="none" d="M0 0h24v24H0z" fill="none" />
   <path d="M16.7 8a3 3 0 0 0 -2.7 -2h-4a3 3 0 0 0 0 6h4a3 3 0 0 1 0 6h-4a3 3 0 0 1 -2.7 -2" />
   <path d="M12 3v3m0 12v3" />

--- a/resources/views/components/icon/paid-invoice.blade.php
+++ b/resources/views/components/icon/paid-invoice.blade.php
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+  <path d="M16.7 8a3 3 0 0 0 -2.7 -2h-4a3 3 0 0 0 0 6h4a3 3 0 0 1 0 6h-4a3 3 0 0 1 -2.7 -2" />
+  <path d="M12 3v3m0 12v3" />
+</svg>

--- a/resources/views/components/icon/paid-invoice.blade.php
+++ b/resources/views/components/icon/paid-invoice.blade.php
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" {{ $attributes->merge(['class' => 'icon']) }}>
   <path stroke="none" d="M0 0h24v24H0z" fill="none" />
   <path d="M16.7 8a3 3 0 0 0 -2.7 -2h-4a3 3 0 0 0 0 6h4a3 3 0 0 1 0 6h-4a3 3 0 0 1 -2.7 -2" />
   <path d="M12 3v3m0 12v3" />

--- a/resources/views/components/icon/project.blade.php
+++ b/resources/views/components/icon/project.blade.php
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-adjustments-alt" width="32" height="32" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" {{ $attributes->merge(['class' => 'icon']) }}>
   <path stroke="none" d="M0 0h24v24H0z" fill="none" />
   <rect x="4" y="8" width="4" height="4" />
   <line x1="6" y1="4" x2="6" y2="8" />

--- a/resources/views/components/icon/project.blade.php
+++ b/resources/views/components/icon/project.blade.php
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" {{ $attributes->merge(['class' => 'icon']) }}>
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" role="none" {{ $attributes->merge(['class' => 'icon']) }}>
   <path stroke="none" d="M0 0h24v24H0z" fill="none" />
   <rect x="4" y="8" width="4" height="4" />
   <line x1="6" y1="4" x2="6" y2="8" />

--- a/resources/views/components/icon/project.blade.php
+++ b/resources/views/components/icon/project.blade.php
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-adjustments-alt" width="32" height="32" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+  <rect x="4" y="8" width="4" height="4" />
+  <line x1="6" y1="4" x2="6" y2="8" />
+  <line x1="6" y1="12" x2="6" y2="20" />
+  <rect x="10" y="14" width="4" height="4" />
+  <line x1="12" y1="4" x2="12" y2="14" />
+  <line x1="12" y1="18" x2="12" y2="20" />
+  <rect x="16" y="5" width="4" height="4" />
+  <line x1="18" y1="4" x2="18" y2="5" />
+  <line x1="18" y1="9" x2="18" y2="20" />
+</svg>

--- a/resources/views/components/icon/task.blade.php
+++ b/resources/views/components/icon/task.blade.php
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" {{ $attributes->merge(['class' => 'icon']) }}>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" role="none" {{ $attributes->merge(['class' => 'icon']) }}>
   <path stroke="none" d="M0 0h24v24H0z" fill="none" />
   <path d="M11 7h-5a2 2 0 0 0 -2 2v9a2 2 0 0 0 2 2h9a2 2 0 0 0 2 -2v-5" />
   <line x1="10" y1="14" x2="20" y2="4" />

--- a/resources/views/components/icon/task.blade.php
+++ b/resources/views/components/icon/task.blade.php
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+  <rect x="4" y="4" width="6" height="6" rx="1" />
+  <rect x="4" y="14" width="6" height="6" rx="1" />
+  <rect x="14" y="14" width="6" height="6" rx="1" />
+  <line x1="14" y1="7" x2="20" y2="7" />
+  <line x1="17" y1="4" x2="17" y2="10" />
+</svg>

--- a/resources/views/components/icon/task.blade.php
+++ b/resources/views/components/icon/task.blade.php
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" {{ $attributes->merge(['class' => 'icon']) }}>
   <path stroke="none" d="M0 0h24v24H0z" fill="none" />
   <rect x="4" y="4" width="6" height="6" rx="1" />
   <rect x="4" y="14" width="6" height="6" rx="1" />

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -19,7 +19,7 @@
                   <div class="row align-items-center">
                     <div class="col-auto">
                       <span class="bg-yellow text-white avatar">                       
-	                      <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M14 3v4a1 1 0 0 0 1 1h4" /><path d="M17 21h-10a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h7l5 5v11a2 2 0 0 1 -2 2z" /><line x1="9" y1="7" x2="10" y2="7" /><line x1="9" y1="13" x2="15" y2="13" /><line x1="13" y1="17" x2="15" y2="17" /></svg>
+	                     <x-icon.invoice />
                       </span>
                     </div>
                     <div class="col">
@@ -41,7 +41,7 @@
                   <div class="row align-items-center">
                     <div class="col-auto">
                       <span class="bg-lime text-white avatar">
-                        <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"></path><path d="M16.7 8a3 3 0 0 0 -2.7 -2h-4a3 3 0 0 0 0 6h4a3 3 0 0 1 0 6h-4a3 3 0 0 1 -2.7 -2"></path><path d="M12 3v3m0 12v3"></path></svg>
+                        <x-icon.paid-invoice />
                       </span>
                     </div>
                     <div class="col">
@@ -65,7 +65,7 @@
                   <div class="row align-items-center">
                     <div class="col-auto">
                       <span class="bg-teal text-white avatar">                   
-	                  <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><rect x="3" y="7" width="18" height="13" rx="2" /><path d="M8 7v-2a2 2 0 0 1 2 -2h4a2 2 0 0 1 2 2v2" /><line x1="12" y1="12" x2="12" y2="12.01" /><path d="M3 13a20 20 0 0 0 18 0" /></svg>
+	                     <x-icon.offer />
                       </span>
                     </div>
                     <div class="col">
@@ -89,7 +89,7 @@
                   <div class="row align-items-center">
                     <div class="col-auto">
                       <span class="bg-blue text-white avatar">
-	                <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><rect x="4" y="4" width="6" height="6" rx="1" /><rect x="4" y="14" width="6" height="6" rx="1" /><rect x="14" y="14" width="6" height="6" rx="1" /><line x1="14" y1="7" x2="20" y2="7" /><line x1="17" y1="4" x2="17" y2="10" /></svg>
+	                       <x-icon.project />
                       </span>
                     </div>
                     <div class="col">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -72,12 +72,7 @@
                   <li class="nav-item  @if(Request::is('dashboard')){{ 'active' }}@endif">
                     <a class="nav-link" href="/" >
                       <span class="nav-link-icon d-md-none d-lg-inline-block">
-                        <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-dashboard" width="32" height="32" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
-                          <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-                          <circle cx="12" cy="13" r="2"></circle>
-                          <line x1="13.45" y1="11.55" x2="15.5" y2="9.5"></line>
-                          <path d="M6.4 20a9 9 0 1 1 11.2 0z"></path>
-                       </svg>
+                        <x-icon.dashboard />
                       </span>
                       <span class="nav-link-title">
                         {{ __('Dashboard') }}
@@ -88,7 +83,7 @@
                   <li class="nav-item  @if(Request::is('clients')){{ 'active' }}@endif dropdown">
                     <a class="nav-link dropdown-toggle" href="#navbar-base" data-toggle="dropdown" role="button" aria-expanded="false" >
                       <span class="nav-link-icon d-md-none d-lg-inline-block">
-                        <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><circle cx="9" cy="7" r="4" /><path d="M3 21v-2a4 4 0 0 1 4 -4h4a4 4 0 0 1 4 4v2" /><path d="M16 3.13a4 4 0 0 1 0 7.75" /><path d="M21 21v-2a4 4 0 0 0 -3 -3.85" /></svg>
+                        <x-icon.client />
                       </span>
                       <span class="nav-link-title">
                         {{ __('Clients') }}
@@ -115,7 +110,7 @@
                   <li class="nav-item  @if(Request::is('invoices')){{ 'active' }}@endif dropdown">
                     <a class="nav-link dropdown-toggle" href="#navbar-base" data-toggle="dropdown" role="button" aria-expanded="false" >
                       <span class="nav-link-icon d-md-none d-lg-inline-block">
-                        <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M14 3v4a1 1 0 0 0 1 1h4" /><path d="M17 21h-10a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h7l5 5v11a2 2 0 0 1 -2 2z" /><line x1="9" y1="7" x2="10" y2="7" /><line x1="9" y1="13" x2="15" y2="13" /><line x1="13" y1="17" x2="15" y2="17" /></svg>
+                        <x-icon.invoice />
                       </span>
                       <span class="nav-link-title">
                         {{ __('Invoices') }}
@@ -153,11 +148,7 @@
                   <li class="nav-item  @if(Request::is('quotes')){{ 'active' }}@endif dropdown">
                     <a class="nav-link dropdown-toggle" href="#navbar-base" data-toggle="dropdown" role="button" aria-expanded="false" >
                       <span class="nav-link-icon d-md-none d-lg-inline-block">
-                        <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-quote" width="32" height="32" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
-                          <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-                          <path d="M10 11h-4a1 1 0 0 1 -1 -1v-3a1 1 0 0 1 1 -1h3a1 1 0 0 1 1 1v6c0 2.667 -1.333 4.333 -4 5"></path>
-                          <path d="M19 11h-4a1 1 0 0 1 -1 -1v-3a1 1 0 0 1 1 -1h3a1 1 0 0 1 1 1v6c0 2.667 -1.333 4.333 -4 5"></path>
-                       </svg>
+                        <x-icon.offer />
                       </span>
                       <span class="nav-link-title">
                         {{ __('Quotation') }}
@@ -190,18 +181,7 @@
                   <li class="nav-item  @if(Request::is('projects')){{ 'active' }}@endif dropdown">
                     <a class="nav-link dropdown-toggle" href="#navbar-base" data-toggle="dropdown" role="button" aria-expanded="false" >
                       <span class="nav-link-icon d-md-none d-lg-inline-block">
-                        <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-adjustments-alt" width="32" height="32" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
-                          <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-                          <rect x="4" y="8" width="4" height="4"></rect>
-                          <line x1="6" y1="4" x2="6" y2="8"></line>
-                          <line x1="6" y1="12" x2="6" y2="20"></line>
-                          <rect x="10" y="14" width="4" height="4"></rect>
-                          <line x1="12" y1="4" x2="12" y2="14"></line>
-                          <line x1="12" y1="18" x2="12" y2="20"></line>
-                          <rect x="16" y="5" width="4" height="4"></rect>
-                          <line x1="18" y1="4" x2="18" y2="5"></line>
-                          <line x1="18" y1="9" x2="18" y2="20"></line>
-                       </svg>
+                        <x-icon.project />
                       </span>
                       <span class="nav-link-title">
                         {{ __('Projects') }}
@@ -240,7 +220,7 @@
                   <li class="nav-item  @if(Request::is('mytasks')){{ 'active' }}@endif">
                     <a class="nav-link" href="/mytasks" >
                       <span class="nav-link-icon d-md-none d-lg-inline-block">
-                        <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><rect x="4" y="4" width="6" height="6" rx="1" /><rect x="4" y="14" width="6" height="6" rx="1" /><rect x="14" y="14" width="6" height="6" rx="1" /><line x1="14" y1="7" x2="20" y2="7" /><line x1="17" y1="4" x2="17" y2="10" /></svg>
+                        <x-icon.task />
                       </span>
                       <span class="nav-link-title">
                         {{ __('Tasks') }}
@@ -251,11 +231,7 @@
                   <li class="nav-item  @if(Request::is('expenses')){{ 'active' }}@endif">
                     <a class="nav-link" href="/expenses" >
                       <span class="nav-link-icon d-md-none d-lg-inline-block">
-                        <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-wallet" width="32" height="32" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
-                          <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-                          <path d="M17 8v-3a1 1 0 0 0 -1 -1h-10a2 2 0 0 0 0 4h12a1 1 0 0 1 1 1v3m0 4v3a1 1 0 0 1 -1 1h-12a2 2 0 0 1 -2 -2v-12"></path>
-                          <path d="M20 12v4h-4a2 2 0 0 1 0 -4h4"></path>
-                       </svg>
+                        <x-icon.expense />
                       </span>
                       <span class="nav-link-title">
                         {{ __('Expenses') }}
@@ -268,12 +244,7 @@
                   <li class="nav-item  @if(Request::is('filemanager')){{ 'active' }}@endif">
                     <a class="nav-link" href="/filemanager" >
                       <span class="nav-link-icon d-md-none d-lg-inline-block">
-                        <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-cloud-upload" width="32" height="32" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
-                          <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-                          <path d="M7 18a4.6 4.4 0 0 1 0 -9a5 4.5 0 0 1 11 2h1a3.5 3.5 0 0 1 0 7h-1"></path>
-                          <polyline points="9 15 12 12 15 15"></polyline>
-                          <line x1="12" y1="12" x2="12" y2="21"></line>
-                       </svg>
+                        <x-icon.file-manager />
                       </span>
                       <span class="nav-link-title">
                         {{ __('File_Manager') }}
@@ -284,7 +255,8 @@
                   @if(Auth::user()->usertype==1)
                   <li class="nav-item  @if(Request::is('lead')){{ 'active' }}@endif dropdown">
                     <a class="nav-link dropdown-toggle" href="#navbar-base" data-toggle="dropdown" role="button" aria-expanded="false" >
-                      <span class="nav-link-icon d-md-none d-lg-inline-block"><svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z"/><polyline points="12 3 20 7.5 20 16.5 12 21 4 16.5 4 7.5 12 3" /><line x1="12" y1="12" x2="20" y2="7.5" /><line x1="12" y1="12" x2="12" y2="21" /><line x1="12" y1="12" x2="4" y2="7.5" /><line x1="16" y1="5.25" x2="8" y2="9.75" /></svg>
+                      <span class="nav-link-icon d-md-none d-lg-inline-block">
+                        <x-icon.admin-panel />
                       </span>
                       <span class="nav-link-title">
                         {{ __('Admin_Panel') }}


### PR DESCRIPTION
I moved the icon definitions into separate icon components. For now the following icon components exist:
- `<x-icon.admin-panel />`
- `<x-icon.client />`
- `<x-icon.dashboard />`
- `<x-icon.delete />`
- `<x-icon.edit />`
- `<x-icon.expense />`
- `<x-icon.file-manager />`
- `<x-icon.invoice />`
- `<x-icon.offer />`
- `<x-icon.paid-invoice />`
- `<x-icon.project />`
- `<x-icon.task />`

Also those icons are hidden for screen readers and only have a decorational function.