### PR TITLE
Feature: Add well-known url for changing the password

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -23,6 +23,11 @@ use App\Http\Controllers\Project;
 |
 */
 
+Route::redirect(
+    '.well-known/change-password',
+    'forgot-password'
+);
+
 Route::get('/', function () {
     return redirect('/login');
 });


### PR DESCRIPTION
I added a redirect from `/.well-known/change-password` to `/forgot-password` so e.g. password wallets can detect the location of the password change form.