### PR TITLE
Feature: Rename database table columns and adjust their data types

### DIFF
--- a/app/Http/Controllers/ClientController.php
+++ b/app/Http/Controllers/ClientController.php
@@ -119,7 +119,7 @@ class ClientController extends Controller
      */
     public function destroy(Client $client)
     {
-        Invoice::where('userid', $client->id)->delete();
+        Invoice::forClient( $client )->delete();
         $client->projects()->delete();
         $client->delete();
 

--- a/app/Http/Controllers/ClientController.php
+++ b/app/Http/Controllers/ClientController.php
@@ -8,8 +8,6 @@ use App\Models\Client;
 use App\Models\Invoice;
 use App\Models\Project;
 
-use Illuminate\Support\Facades\Auth;
-
 class ClientController extends Controller
 {
     /**
@@ -46,7 +44,7 @@ class ClientController extends Controller
     {
         $client = Client::create([
             ...$request->all(),
-            'addedby' => Auth::id(),
+            'addedby' => auth()->user()->id,
         ]);
 
         // Mail::to($request->email)->send(new welcomemail($client));

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -59,7 +59,7 @@ class DashboardController extends Controller
         $counts['prjincompleted'] = Project::where('status',5)->count();
 
         $tasks = Task::where(
-            'assignedto',
+            'assigned_user_id',
             Auth::id()
         )->where('status',1)->orderby('id','desc')->get();
         $invoices = Invoice::where(

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -11,7 +11,6 @@ use App\Models\Project;
 use App\Models\Task;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 
 class DashboardController extends Controller
 {
@@ -60,7 +59,7 @@ class DashboardController extends Controller
 
         $tasks = Task::where(
             'assigned_user_id',
-            Auth::id()
+            auth()->user()->id
         )->where('status',1)->orderby('id','desc')->get();
         $invoices = Invoice::where(
             'invostatus',
@@ -69,7 +68,7 @@ class DashboardController extends Controller
         $notifications = Notification::where(
             'status',
             1
-        )->where('toid', Auth::id())->orderby('id','desc')->paginate(5);
+        )->where('toid', auth()->user()->id)->orderby('id','desc')->paginate(5);
 
         return view('dashboard')->with([
             'clients' => $client,

--- a/app/Http/Controllers/ExpenseController.php
+++ b/app/Http/Controllers/ExpenseController.php
@@ -6,7 +6,6 @@ use App\Models\ExpenseManager;
 use App\Models\Project;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 use Spatie\QueryBuilder\QueryBuilder;
 
 class ExpenseController extends Controller
@@ -49,7 +48,7 @@ class ExpenseController extends Controller
     {
         $expense = new ExpenseManager([
             ...$request->all(),
-            'auth' => Auth::id(),
+            'auth' => auth()->user()->id,
             'status' => 1,
         ]);
 

--- a/app/Http/Controllers/GatewayController.php
+++ b/app/Http/Controllers/GatewayController.php
@@ -47,7 +47,7 @@ class GatewayController extends Controller
                     $paymentreceipt->date =date('Y-m-d');
                     $paymentreceipt->transation =$input['razorpay_payment_id'];
                     $paymentreceipt->note ='Paid using Razorpay';
-                    $paymentreceipt->gateway ='Razorpay';
+                    $paymentreceipt->payment_gateway_id = $gateways->id;
                     $paymentreceipt->save();
                 
                     $currentpaid =  $invoices->paidamount;
@@ -96,7 +96,7 @@ class GatewayController extends Controller
         $paymentreceipt->date =date('Y-m-d');
         $paymentreceipt->transation =$request->stripeToken;
         $paymentreceipt->note ='Paid using Stripe';
-        $paymentreceipt->gateway ='Stripe';
+        $paymentreceipt->payment_gateway_id = $gateways->id;
         $paymentreceipt->save();
       
         $currentpaid =  $invoices->paidamount;
@@ -119,6 +119,7 @@ class GatewayController extends Controller
 
     public function paypalhandlePayment(Request $request)
     {
+        $gateway =PaymentGateway::findOrFail(1);
         $oderidd =$request->invoice_id;
         $paymentid =$request->orderID;
        
@@ -132,6 +133,7 @@ class GatewayController extends Controller
             $paymentreceipt->date =date('Y-m-d');
             $paymentreceipt->transation =$request->orderID;
             $paymentreceipt->note ='Paid using Paypal';
+            $paymentreceipt->payment_gateway_id = $gateway->id;
             $paymentreceipt->gateway ='Paypal';
             $paymentreceipt->save();
           

--- a/app/Http/Controllers/GatewayController.php
+++ b/app/Http/Controllers/GatewayController.php
@@ -39,10 +39,10 @@ class GatewayController extends Controller
             try 
             {
                 $response = $api->payment->fetch($input['razorpay_payment_id'])->capture(array('amount'=>$payment['amount'])); 
-                 $invoices = Invoice::findOrFail($request->invoid);
+                 $invoices = Invoice::findOrFail($request->invoice_id);
                     $paidamountnow = $invoices->totalamount - $invoices->paidamount;
                     $paymentreceipt =new PaymentReceipt();
-                    $paymentreceipt->invoiceid=$request->invoid;
+                    $paymentreceipt->invoice_id=$request->invoice_id;
                     $paymentreceipt->amount =$paidamountnow;
                     $paymentreceipt->date =date('Y-m-d');
                     $paymentreceipt->transation =$input['razorpay_payment_id'];
@@ -78,7 +78,7 @@ class GatewayController extends Controller
     public function stripepayment(Request $request)
     {
         $gateways =PaymentGateway::findOrFail(2);
-        $invoices = Invoice::findOrFail($request->invoid);
+        $invoices = Invoice::findOrFail($request->invoice_id);
         $setting = Setting::find(1);
         $paidamountnow = $invoices->totalamount - $invoices->paidamount;
         $famount = $paidamountnow*100;
@@ -91,7 +91,7 @@ class GatewayController extends Controller
         ]);
           
         $paymentreceipt =new PaymentReceipt();
-        $paymentreceipt->invoiceid=$request->invoid;
+        $paymentreceipt->invoice_id=$request->invoice_id;
         $paymentreceipt->amount =$paidamountnow;
         $paymentreceipt->date =date('Y-m-d');
         $paymentreceipt->transation =$request->stripeToken;
@@ -119,15 +119,15 @@ class GatewayController extends Controller
 
     public function paypalhandlePayment(Request $request)
     {
-        $oderidd =$request->invoid;
+        $oderidd =$request->invoice_id;
         $paymentid =$request->orderID;
        
         if($request->orderID!=NULL)
         {
-            $invoices = Invoice::findOrFail($request->invoid);
+            $invoices = Invoice::findOrFail($request->invoice_id);
             $paidamountnow = $invoices->totalamount - $invoices->paidamount;
             $paymentreceipt =new PaymentReceipt();
-            $paymentreceipt->invoiceid=$request->invoid;
+            $paymentreceipt->invoice_id=$request->invoice_id;
             $paymentreceipt->amount =$paidamountnow;
             $paymentreceipt->date =date('Y-m-d');
             $paymentreceipt->transation =$request->orderID;

--- a/app/Http/Controllers/Invoice/ItemController.php
+++ b/app/Http/Controllers/Invoice/ItemController.php
@@ -7,7 +7,6 @@ use App\Models\Invoice;
 use App\Models\InvoiceItem;
 use App\Models\Setting;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 
 class ItemController extends Controller {
     /**

--- a/app/Http/Controllers/InvoiceController.php
+++ b/app/Http/Controllers/InvoiceController.php
@@ -28,7 +28,7 @@ class InvoiceController extends Controller
         $invoices = QueryBuilder::for( Invoice::class )
             ->allowedFilters([
                 'title',
-                'userid',
+                'client_id',
                 'invoid',
                 'invostatus',
             ])
@@ -84,7 +84,7 @@ class InvoiceController extends Controller
             return Invoice::create([
                 'type' => 2,
                 'title' => $request->title,
-                'userid' => $request->userid,
+                'client_id' => $request->client_id,
                 'creator_id' => Auth::id(),
                 'project_id' => $request->project_id,
                 'invoid' => $nextInvoiceNumber,
@@ -332,7 +332,7 @@ class InvoiceController extends Controller
          $invoice =new Invoice();
          $invoice->type=2;
          $invoice->title =$request->title;
-         $invoice->userid =$request->userid;
+         $invoice->client_id =$request->client_id;
          $invoice->creator_id = Auth::id();
          if(Invoice::where('type',2)->count()==0){
          $invoice->invoid =1; }

--- a/app/Http/Controllers/InvoiceController.php
+++ b/app/Http/Controllers/InvoiceController.php
@@ -68,7 +68,7 @@ class InvoiceController extends Controller
      * @return \Illuminate\Http\Response
      */
     public function store(Request $request) {
-        $invoice = DB::transaction(function () {
+        $invoice = DB::transaction(function () use ( $request ) {
             $lastInvoice = (
                 Invoice::where('type', 2)
                     ->orderby('id', 'desc')
@@ -105,8 +105,8 @@ class InvoiceController extends Controller
     public function edit(
         Invoice $invoice
     ) {
-        $invoiceItems = $invoices->items()->paginate(100);
-        $payments = $invoices->payments()->paginate(100);
+        $invoiceItems = $invoice->items()->paginate(100);
+        $payments = $invoice->payments()->paginate(100);
 
         return view('app.editinvoice')->with([
             'invoice' => $invoice,

--- a/app/Http/Controllers/InvoiceController.php
+++ b/app/Http/Controllers/InvoiceController.php
@@ -319,7 +319,9 @@ class InvoiceController extends Controller
       $invoices->markAsUnpaid();
       $invoices->type =2;             
       $invoices->save();   
-      return redirect('/invoice/edit/'.$request->id)->with('success', 'Converted as Invoice');  
+      return redirect()->route('invoices.edit', [ $invoices ])->with([
+        'success' => 'Converted as Invoice',
+      ]);
      }
 
 
@@ -364,7 +366,7 @@ class InvoiceController extends Controller
              $invoice->recorringnextdate = $getinvocedate->addYear(); 
          }                       
          $invoice->save();        
-         $lastid = $invoice->id;
-        return redirect('/invoice/edit/'.$lastid);
+
+        return redirect()->route('invoices.edit', [ $invoice ]);
      }
 }

--- a/app/Http/Controllers/InvoiceController.php
+++ b/app/Http/Controllers/InvoiceController.php
@@ -85,7 +85,7 @@ class InvoiceController extends Controller
                 'type' => 2,
                 'title' => $request->title,
                 'userid' => $request->userid,
-                'adminid' => Auth::id(),
+                'creator_id' => Auth::id(),
                 'project_id' => $request->project_id,
                 'invoid' => $nextInvoiceNumber,
             ]);
@@ -333,7 +333,7 @@ class InvoiceController extends Controller
          $invoice->type=2;
          $invoice->title =$request->title;
          $invoice->userid =$request->userid;
-         $invoice->adminid = Auth::id();  
+         $invoice->creator_id = Auth::id();
          if(Invoice::where('type',2)->count()==0){
          $invoice->invoid =1; }
          else{

--- a/app/Http/Controllers/InvoiceController.php
+++ b/app/Http/Controllers/InvoiceController.php
@@ -157,7 +157,6 @@ class InvoiceController extends Controller
         {
             $paymentreceipt =new PaymentReceipt();
             $paymentreceipt->invoice_id=$request->invoice_id;
-            $paymentreceipt->adminid = auth()->user()->id;
             $paymentreceipt->amount =$request->amount;
             $paymentreceipt->date =$request->date;
             $paymentreceipt->transation =$request->transation;
@@ -250,7 +249,6 @@ class InvoiceController extends Controller
         {
             $paymentreceipt =new PaymentReceipt();
             $paymentreceipt->invoice_id=$request->invoice_id;
-            $paymentreceipt->adminid = auth()->user()->id;
             $paymentreceipt->amount =-$request->amount;
             $paymentreceipt->date =$request->date;
             $paymentreceipt->transation =$request->transation;

--- a/app/Http/Controllers/InvoiceController.php
+++ b/app/Http/Controllers/InvoiceController.php
@@ -156,7 +156,7 @@ class InvoiceController extends Controller
         if($request->amount!=NULL)
         {
             $paymentreceipt =new PaymentReceipt();
-            $paymentreceipt->invoiceid=$request->invoiceid;
+            $paymentreceipt->invoice_id=$request->invoice_id;
             $paymentreceipt->adminid = auth()->user()->id;
             $paymentreceipt->amount =$request->amount;
             $paymentreceipt->date =$request->date;
@@ -164,7 +164,7 @@ class InvoiceController extends Controller
             $paymentreceipt->note =$request->note;
             $paymentreceipt->save();
 
-            $invoices = Invoice::findOrFail($request->invoiceid);
+            $invoices = Invoice::findOrFail($request->invoice_id);
             $currentpaid =  $invoices->paidamount;
             $invoices->paidamount = $currentpaid + $request->amount; 
             $nowpaid=  $currentpaid + $request->amount;
@@ -192,12 +192,12 @@ class InvoiceController extends Controller
     public function deletepayment(Request $request)
      {       
          $payment =$request->id;      
-         $invoid =$request->invo;        
+         $invoid =$request->invoice_id;
          if($invoid!=NULL)
          {
-           $meta = PaymentReceipt::where('invoiceid',$invoid)->where('id',$payment)->first();
+           $meta = PaymentReceipt::where('invoice_id',$invoice_id)->where('id',$payment)->first();
            $getamount = $meta->amount;
-           $invoices = Invoice::findOrFail($request->invo); 
+           $invoices = Invoice::findOrFail($request->invoice_id);
            $getpaidamount = $invoices->paidamount;
            $revesedpayment = $getpaidamount - $getamount;
            $invoices->paidamount =$revesedpayment;
@@ -249,7 +249,7 @@ class InvoiceController extends Controller
         if($request->amount!=NULL)
         {
             $paymentreceipt =new PaymentReceipt();
-            $paymentreceipt->invoiceid=$request->invoiceid;
+            $paymentreceipt->invoice_id=$request->invoice_id;
             $paymentreceipt->adminid = auth()->user()->id;
             $paymentreceipt->amount =-$request->amount;
             $paymentreceipt->date =$request->date;
@@ -257,7 +257,7 @@ class InvoiceController extends Controller
             $paymentreceipt->note =$request->note;
             $paymentreceipt->save();
 
-            $invoices = Invoice::findOrFail($request->invoiceid);
+            $invoices = Invoice::findOrFail($request->invoice_id);
             $currentpaid =  $invoices->paidamount;
             $invoices->paidamount = $currentpaid - $request->amount; 
             $invoices->markAsRefunded();

--- a/app/Http/Controllers/InvoiceController.php
+++ b/app/Http/Controllers/InvoiceController.php
@@ -12,7 +12,6 @@ use App\Models\PaymentReceipt;
 use App\Models\Business;
 use Spatie\QueryBuilder\QueryBuilder;
 
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 
 class InvoiceController extends Controller
@@ -85,7 +84,7 @@ class InvoiceController extends Controller
                 'type' => 2,
                 'title' => $request->title,
                 'client_id' => $request->client_id,
-                'creator_id' => Auth::id(),
+                'creator_id' => auth()->user()->id,
                 'project_id' => $request->project_id,
                 'invoid' => $nextInvoiceNumber,
             ]);
@@ -158,7 +157,7 @@ class InvoiceController extends Controller
         {
             $paymentreceipt =new PaymentReceipt();
             $paymentreceipt->invoiceid=$request->invoiceid;
-            $paymentreceipt->adminid = Auth::id();
+            $paymentreceipt->adminid = auth()->user()->id;
             $paymentreceipt->amount =$request->amount;
             $paymentreceipt->date =$request->date;
             $paymentreceipt->transation =$request->transation;
@@ -251,7 +250,7 @@ class InvoiceController extends Controller
         {
             $paymentreceipt =new PaymentReceipt();
             $paymentreceipt->invoiceid=$request->invoiceid;
-            $paymentreceipt->adminid = Auth::id();
+            $paymentreceipt->adminid = auth()->user()->id;
             $paymentreceipt->amount =-$request->amount;
             $paymentreceipt->date =$request->date;
             $paymentreceipt->transation =$request->transation;
@@ -333,7 +332,7 @@ class InvoiceController extends Controller
          $invoice->type=2;
          $invoice->title =$request->title;
          $invoice->client_id =$request->client_id;
-         $invoice->creator_id = Auth::id();
+         $invoice->creator_id = auth()->user()->id;
          if(Invoice::where('type',2)->count()==0){
          $invoice->invoid =1; }
          else{

--- a/app/Http/Controllers/OfferController.php
+++ b/app/Http/Controllers/OfferController.php
@@ -20,7 +20,7 @@ class OfferController extends Controller {
     $offers = QueryBuilder::for( Invoice::class )
       ->allowedFilters([
         'title',
-        'userid',
+        'client_id',
         'quoteid',
         'quotestat',
       ])
@@ -47,7 +47,7 @@ class OfferController extends Controller {
       return Invoice::create([
         'type' => 1,
         'title' => $request->title,
-        'userid' => $request->userid,
+        'client_id' => $request->client_id,
         'creator_id' => Auth::id(),
         'quotestat' => 1,
         'quoteid' => $nextOfferNumber,

--- a/app/Http/Controllers/OfferController.php
+++ b/app/Http/Controllers/OfferController.php
@@ -48,7 +48,7 @@ class OfferController extends Controller {
         'type' => 1,
         'title' => $request->title,
         'client_id' => $request->client_id,
-        'creator_id' => Auth::id(),
+        'creator_id' => auth()->user()->id,
         'quotestat' => 1,
         'quoteid' => $nextOfferNumber,
       ]);

--- a/app/Http/Controllers/OfferController.php
+++ b/app/Http/Controllers/OfferController.php
@@ -48,7 +48,7 @@ class OfferController extends Controller {
         'type' => 1,
         'title' => $request->title,
         'userid' => $request->userid,
-        'adminid' => Auth::id(),
+        'creator_id' => Auth::id(),
         'quotestat' => 1,
         'quoteid' => $nextOfferNumber,
       ]);

--- a/app/Http/Controllers/PayInvoiceController.php
+++ b/app/Http/Controllers/PayInvoiceController.php
@@ -26,11 +26,11 @@ class PayInvoiceController extends Controller {
     $business = Business::find(1);
     $gateways = PaymentGateway::where('status', 1)->get();
     $invoiceItems = $invoice->items()->paginate(100);
-    $paymentreceipt = $invoice->payments()->paginate(100);
+    $payments = $invoice->payments()->paginate(100);
 
     return view('app.payinvoice')->with([
       'invoice' => $invoice,
-      'invoice_items' => $invoiceItems,
+      'invoiceItems' => $invoiceItems,
       'payments' => $payments,
       'business' => $business,
       'gateways' => $gateways

--- a/app/Http/Controllers/Project/NoteController.php
+++ b/app/Http/Controllers/Project/NoteController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers\Project;
 use App\Http\Controllers\Controller;
 use App\Models\Project;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 
 class NoteController extends Controller {
   /**

--- a/app/Http/Controllers/Project/NoteController.php
+++ b/app/Http/Controllers/Project/NoteController.php
@@ -35,7 +35,6 @@ class NoteController extends Controller {
     $projectNote = $project->note;
     $projectNote->update([
       'note' => $request->note,
-      'admin' => Auth::id(),
     ]);
 
     return redirect()->back()->with([

--- a/app/Http/Controllers/Project/TaskController.php
+++ b/app/Http/Controllers/Project/TaskController.php
@@ -24,7 +24,7 @@ class TaskController extends Controller {
     $tasks = (
       $project
         ->tasks()
-        ->where('assignedto', Auth::id())
+        ->where('assigned_user_id', Auth::id())
         ->paginate(30)
     );
 
@@ -46,7 +46,7 @@ class TaskController extends Controller {
     Project $project,
     Task $task
   ) {
-    if ( $task->assignedto !== Auth::id() ) {
+    if ( $task->assigned_user_id !== Auth::id() ) {
       abort(404);
     }
 
@@ -75,16 +75,16 @@ class TaskController extends Controller {
     $task = $project->tasks()->create([
       'creator_id' => Auth::id(),
       'task' => $request->task,
-      'assignedto' => $request->assignedto,
+      'assigned_user_id' => $request->assigned_user_id,
       'type' => $request->type,
       'status' => 1,
     ]);
 
     //send notification
-    if ( $request->assignedto ) {
+    if ( $request->assigned_user_id ) {
       $notification = new Notification();
       $notification->fromid = Auth::id();
-      $notification->toid = $request->assignedto;
+      $notification->toid = $request->assigned_user_id;
       $notification->message = 'New Project Task Assigned #' . $task->id;
       $notification->link = route('tasks.show', [ $task ]);
       $notification->style = $request->type;
@@ -110,7 +110,7 @@ class TaskController extends Controller {
     Task $task,
   ) {
     if ( !in_array( Auth::id(), [
-      $task->assignedto,
+      $task->assigned_user_id,
       $task->creator_id
     ]) ) {
       abort(404);

--- a/app/Http/Controllers/Project/TaskController.php
+++ b/app/Http/Controllers/Project/TaskController.php
@@ -10,7 +10,6 @@ use App\Models\Task;
 use App\Models\TaskItem;
 use App\Models\User;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 
 class TaskController extends Controller {
   /**
@@ -24,7 +23,7 @@ class TaskController extends Controller {
     $tasks = (
       $project
         ->tasks()
-        ->where('assigned_user_id', Auth::id())
+        ->where('assigned_user_id', auth()->user()->id)
         ->paginate(30)
     );
 
@@ -46,7 +45,7 @@ class TaskController extends Controller {
     Project $project,
     Task $task
   ) {
-    if ( $task->assigned_user_id !== Auth::id() ) {
+    if ( auth()->user()->isNot( $task->assigned_user ) ) {
       abort(404);
     }
 
@@ -73,7 +72,7 @@ class TaskController extends Controller {
     Project $project
   ) {
     $task = $project->tasks()->create([
-      'creator_id' => Auth::id(),
+      'creator_id' => auth()->user()->id,
       'task' => $request->task,
       'assigned_user_id' => $request->assigned_user_id,
       'type' => $request->type,
@@ -83,7 +82,7 @@ class TaskController extends Controller {
     //send notification
     if ( $request->assigned_user_id ) {
       $notification = new Notification();
-      $notification->fromid = Auth::id();
+      $notification->fromid = auth()->user()->id;
       $notification->toid = $request->assigned_user_id;
       $notification->message = 'New Project Task Assigned #' . $task->id;
       $notification->link = route('tasks.show', [ $task ]);
@@ -109,7 +108,7 @@ class TaskController extends Controller {
     Request $request,
     Task $task,
   ) {
-    if ( !in_array( Auth::id(), [
+    if ( !in_array( auth()->user()->id, [
       $task->assigned_user_id,
       $task->creator_id
     ]) ) {

--- a/app/Http/Controllers/Project/UpdateController.php
+++ b/app/Http/Controllers/Project/UpdateController.php
@@ -21,7 +21,7 @@ class UpdateController extends Controller {
   ) {
     $project->updates()->create([
       'task_id' => $request->task_id,
-      'creator_id' => Auth::id(),
+      'creator_id' => auth()->user()->id,
       'message' => $request->message,
     ]);
 

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -7,7 +7,6 @@ use App\Http\Requests\UpdateProjectRequest;
 use App\Models\Client;
 use App\Models\Project;
 use Carbon\Carbon;
-use Illuminate\Support\Facades\Auth;
 use Spatie\QueryBuilder\QueryBuilder;
 
 class ProjectController extends Controller {
@@ -47,7 +46,7 @@ class ProjectController extends Controller {
     );
 
     $project->note()->create([
-      'creator_id' => Auth::id(),
+      'creator_id' => auth()->user()->id,
       'note' => 'Add Something',
     ]);
 

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -47,7 +47,7 @@ class ProjectController extends Controller {
     );
 
     $project->note()->create([
-      'admin' => Auth::id(),
+      'creator_id' => Auth::id(),
       'note' => 'Add Something',
     ]);
 

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -71,7 +71,7 @@ class ProjectController extends Controller {
     );
 
     $startDate = Carbon::parse( $project->starts_at );
-    $deadline  = Carbon::parse( $project->deadline );
+    $deadline  = Carbon::parse( $project->deadline_at );
     $totalDays = $startDate->diffInDays( $deadline );
     $today = Carbon::now();
     $balanceDays = $today->diffInDays( $deadline );

--- a/app/Http/Controllers/Task/ItemController.php
+++ b/app/Http/Controllers/Task/ItemController.php
@@ -6,7 +6,6 @@ use App\Http\Controllers\Controller;
 use App\Models\Task;
 use App\Models\TaskItem;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 
 class ItemController extends Controller {
   /**
@@ -19,7 +18,7 @@ class ItemController extends Controller {
   public function store(Request $request, Task $task) {
     $task->items()->create([
       'task' => $request->task,
-      'creator_id' => Auth::id(),
+      'creator_id' => auth()->user()->id,
       'status' => 0,
     ]);
 

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -38,7 +38,7 @@ class TaskController extends Controller {
     $taskComments = $task->updates()->orderby('id', 'desc')->paginate(7);
 
     return view('app.viewtask')->with([
-      'project' => $project,
+      'project' => $task->project,
       'task' => $task,
       'taskcomments' => $taskComments,
       'taskItems' => $taskItems,

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers;
 
 use App\Models\Task;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 
 class TaskController extends Controller {
   /**
@@ -15,7 +14,7 @@ class TaskController extends Controller {
   public function index() {
     $tasks = Task::where(
       'assigned_user_id',
-      Auth::id()
+      auth()->user()->id
     )->orderby('id', 'desc')->paginate(20);
 
     return view('app.mytasks')->with([
@@ -30,7 +29,7 @@ class TaskController extends Controller {
    * @return \Illuminate\Http\Response
    */
   public function show(Task $task) {
-    if ( $task->assigned_user_id !== Auth::id() ) {
+    if ( auth()->user()->isNot( $task->assigned_user ) ) {
       abort(404);
     }
 

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -14,7 +14,7 @@ class TaskController extends Controller {
    */
   public function index() {
     $tasks = Task::where(
-      'assignedto',
+      'assigned_user_id',
       Auth::id()
     )->orderby('id', 'desc')->paginate(20);
 
@@ -30,7 +30,7 @@ class TaskController extends Controller {
    * @return \Illuminate\Http\Response
    */
   public function show(Task $task) {
-    if ( $task->assignedto !== Auth::id() ) {
+    if ( $task->assigned_user_id !== Auth::id() ) {
       abort(404);
     }
 

--- a/app/Http/Middleware/Admin.php
+++ b/app/Http/Middleware/Admin.php
@@ -4,7 +4,7 @@ namespace App\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
-use use App\Providers\RouteServiceProvider;
+use App\Providers\RouteServiceProvider;
 
 class Admin
 {

--- a/app/Http/Requests/CreateProjectRequest.php
+++ b/app/Http/Requests/CreateProjectRequest.php
@@ -42,7 +42,7 @@ class CreateProjectRequest extends FormRequest {
         'required',
         'date_format:Y-m-d',
       ],
-      'deadline' => [
+      'deadline_at' => [
         'required',
         'date_format:Y-m-d',
       ],

--- a/app/Http/Requests/UpdateProjectRequest.php
+++ b/app/Http/Requests/UpdateProjectRequest.php
@@ -41,7 +41,7 @@ class UpdateProjectRequest extends FormRequest {
         'nullable',
         'date_format:Y-m-d',
       ],
-      'deadline' => [
+      'deadline_at' => [
         'nullable',
         'date_format:Y-m-d',
       ],

--- a/app/Jobs/CreateRecurringInvoice.php
+++ b/app/Jobs/CreateRecurringInvoice.php
@@ -46,7 +46,7 @@ class CreateRecurringInvoice implements ShouldQueue {
         'type' => 2,
         'title' => $rcinvo->title,
         'userid' => $rcinvo->userid,
-        'adminid' => $rcinvo->adminid,
+        'creator_id' => $rcinvo->creator_id,
         'invoid' => $lastInvoiceNumber++,
         'project_id' => $rcinvo->project_id,
         'recorring' => 1,

--- a/app/Jobs/CreateRecurringInvoice.php
+++ b/app/Jobs/CreateRecurringInvoice.php
@@ -45,7 +45,7 @@ class CreateRecurringInvoice implements ShouldQueue {
       $invoice = Invoice::create([
         'type' => 2,
         'title' => $rcinvo->title,
-        'userid' => $rcinvo->userid,
+        'client_id' => $rcinvo->client_id,
         'creator_id' => $rcinvo->creator_id,
         'invoid' => $lastInvoiceNumber++,
         'project_id' => $rcinvo->project_id,

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -32,6 +32,20 @@ class Invoice extends Model
     ];
 
     /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'client_id',
+        'creator_id',
+        'invoid',
+        'project_id',
+        'title',
+        'type',
+    ];
+
+    /**
      * The accessors to append to the model's array form.
      *
      * @var array

--- a/app/Models/Invoice/Concerns/HasRelations.php
+++ b/app/Models/Invoice/Concerns/HasRelations.php
@@ -14,9 +14,7 @@ trait HasRelations {
    */
   public function client() {
     return $this->belongsTo(
-      Client::class,
-      'userid',
-      'id'
+      Client::class
     );
   }
 

--- a/app/Models/Invoice/Concerns/HasRelations.php
+++ b/app/Models/Invoice/Concerns/HasRelations.php
@@ -6,6 +6,7 @@ use App\Models\Client;
 use App\Models\InvoiceItem;
 use App\Models\PaymentReceipt;
 use App\Models\Project;
+use App\Models\User;
 
 trait HasRelations {
   /**
@@ -46,6 +47,13 @@ trait HasRelations {
     return $this->hasMany(
       PaymentReceipt::class,
       'invoiceid'
+    );
+  }
+
+  public function creator() {
+    return $this->belongsTo(
+      User::class,
+      'creator_id'
     );
   }
 }

--- a/app/Models/Invoice/Concerns/HasRelations.php
+++ b/app/Models/Invoice/Concerns/HasRelations.php
@@ -44,7 +44,7 @@ trait HasRelations {
   public function payments() {
     return $this->hasMany(
       PaymentReceipt::class,
-      'invoiceid'
+      'invoice_id'
     );
   }
 

--- a/app/Models/Invoice/Concerns/HasScopes.php
+++ b/app/Models/Invoice/Concerns/HasScopes.php
@@ -99,7 +99,7 @@ trait HasScopes {
     }
 
     return $query->where(
-      'userid',
+      'client_id',
       $clientId
     );
   }

--- a/app/Models/InvoiceItem.php
+++ b/app/Models/InvoiceItem.php
@@ -4,7 +4,6 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Facades\Auth;
 
 class InvoiceItem extends Model
 {
@@ -45,7 +44,7 @@ class InvoiceItem extends Model
     protected static function booting() {
         self::creating(function ( $model ) {
             if ( empty( $model->creator_id ) ) {
-                $model->creator_id = Auth::id();
+                $model->creator_id = auth()->user()->id;
             }
         });
     }

--- a/app/Models/PaymentReceipt.php
+++ b/app/Models/PaymentReceipt.php
@@ -8,4 +8,12 @@ use Illuminate\Database\Eloquent\Model;
 class PaymentReceipt extends Model
 {
     use HasFactory;
+
+    protected static function booting() {
+        self::creating(function ( $model ) {
+            if ( empty( $model->creator_id ) ) {
+                $model->creator_id = optional( auth()->user() )->id;
+            }
+        });
+    }
 }

--- a/app/Models/PaymentReceipt.php
+++ b/app/Models/PaymentReceipt.php
@@ -16,4 +16,13 @@ class PaymentReceipt extends Model
             }
         });
     }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function paymentGateway() {
+        return $this->belongsTo(
+            PaymentGateway::class
+        );
+    }
 }

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -28,7 +28,7 @@ class Project extends Model
     protected $fillable = [
         'amount',
         'client_id',
-        'deadline',
+        'deadline_at',
         'description',
         'name',
         'starts_at',

--- a/app/Models/ProjectNote.php
+++ b/app/Models/ProjectNote.php
@@ -15,14 +15,14 @@ class ProjectNote extends Model
      * @var array
      */
     protected $fillable = [
-        'admin',
+        'creator_id',
         'note',
         'project_id',
     ];
 
     public function admindata()
 	{
-        return  $this->belongsTo(User::class, 'admin', 'id');
+        return  $this->belongsTo(User::class, 'creator_id', 'id');
     }
 
     public function project() {

--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -17,11 +17,27 @@ class Task extends Model
      * @var array
      */
     protected $fillable = [
-        'assignedto',
+        'assigned_user_id',
         'creator_id',
         'project_id',
         'status',
         'task',
         'type',
     ];
+
+    /**
+     * The accessors to append to the model's array form.
+     *
+     * @var array
+     */
+    protected $appends = [
+        'is_assigned',
+    ];
+
+    /**
+     * @return bool
+     */
+    public function getIsAssignedAttribute() {
+        return $this->assigned_user_id !== null;
+    }
 }

--- a/app/Models/Task/Concerns/HasRelations.php
+++ b/app/Models/Task/Concerns/HasRelations.php
@@ -15,12 +15,15 @@ trait HasRelations {
     );
   }
 
-  public function assigned() {
+  public function assignedUser() {
     return $this->belongsTo(
       User::class,
-      'assignedto',
-      'id'
+      'assigned_user_id'
     );
+  }
+
+  public function assigned_user() {
+    return $this->assignedUser();
   }
 
   public function items() {

--- a/app/Models/User/Concerns/HasRelations.php
+++ b/app/Models/User/Concerns/HasRelations.php
@@ -15,7 +15,7 @@ trait HasRelations {
   public function createdInvoices() {
     return $this->hasMany(
       Invoice::class,
-      'adminid'
+      'creator_id'
     );
   }
 

--- a/app/Models/User/Concerns/HasRelations.php
+++ b/app/Models/User/Concerns/HasRelations.php
@@ -29,7 +29,7 @@ trait HasRelations {
   public function createdPaymentReceipts() {
     return $this->hasMany(
       PaymentReceipt::class,
-      'adminid'
+      'creator_id'
     );
   }
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -9,7 +9,7 @@ use App\Models\Notification;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Auth;
+
 class AppServiceProvider extends ServiceProvider
 {
     /**

--- a/app/View/Components/SelectProject.php
+++ b/app/View/Components/SelectProject.php
@@ -2,6 +2,7 @@
 
 namespace App\View\Components;
 
+use App\Models\Project;
 use Illuminate\View\Component;
 
 class SelectProject extends Component
@@ -16,7 +17,7 @@ class SelectProject extends Component
      *
      * @return void
      */
-    public function __construct( $selected )
+    public function __construct( $selected = null )
     {
         $this->selected = $selected;
     }
@@ -29,7 +30,10 @@ class SelectProject extends Component
     public function render()
     {
         return view('components.select-project', [
-            'projects' => Project::orderBy('name'),
+            'projects' => (
+                Project::select(['name', 'id'])
+                    ->orderBy('name')->get()
+            ),
             'selected' => $this->selected,
         ]);
     }

--- a/database/migrations/2023_10_30_170036_rename_adminid_column_to_creator_id_column_in_invoices_table.php
+++ b/database/migrations/2023_10_30_170036_rename_adminid_column_to_creator_id_column_in_invoices_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class RenameAdminidColumnToCreatorIdColumnInInvoicesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('invoices', function (Blueprint $table) {
+            $table->renameColumn(
+                'adminid',
+                'creator_id'
+            );
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('invoices', function (Blueprint $table) {
+            $table->renameColumn(
+                'creator_id',
+                'adminid'
+            );
+        });
+    }
+}

--- a/database/migrations/2023_10_30_182133_change_creator_id_column_in_invoices_table.php
+++ b/database/migrations/2023_10_30_182133_change_creator_id_column_in_invoices_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ChangeCreatorIdColumnInInvoicesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('invoices', function (Blueprint $table) {
+            $table
+                ->unsignedInteger('creator_id')
+                ->nullable(false)
+                ->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('invoices', function (Blueprint $table) {
+            $table
+                ->text('creator_id')
+                ->nullable(true)
+                ->change();
+        });
+    }
+}

--- a/database/migrations/2023_10_30_182840_rename_admin_column_to_creator_id_column_in_project_notes_table.php
+++ b/database/migrations/2023_10_30_182840_rename_admin_column_to_creator_id_column_in_project_notes_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class RenameAdminColumnToCreatorIdColumnInProjectNotesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('project_notes', function (Blueprint $table) {
+            $table->renameColumn(
+                'admin',
+                'creator_id'
+            );
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('project_notes', function (Blueprint $table) {
+            $table->renameColumn(
+                'creator_id',
+                'admin'
+            );
+        });
+    }
+}

--- a/database/migrations/2023_10_30_182850_change_creator_id_column_in_project_notes_table.php
+++ b/database/migrations/2023_10_30_182850_change_creator_id_column_in_project_notes_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ChangeCreatorIdColumnInProjectNotesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('project_notes', function (Blueprint $table) {
+            $table
+                ->unsignedInteger('creator_id')
+                ->nullable(false)
+                ->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('project_notes', function (Blueprint $table) {
+            $table
+                ->text('creator_id')
+                ->nullable(true)
+                ->change();
+        });
+    }
+}

--- a/database/migrations/2023_10_30_195230_rename_assignedto_column_to_assigned_user_id_column_in_tasks_table.php
+++ b/database/migrations/2023_10_30_195230_rename_assignedto_column_to_assigned_user_id_column_in_tasks_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class RenameAssignedtoColumnToAssignedUserIdColumnInTasksTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->renameColumn(
+                'assignedto',
+                'assigned_user_id'
+            );
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->renameColumn(
+                'assigned_user_id',
+                'assignedto'
+            );
+        });
+    }
+}

--- a/database/migrations/2023_10_30_195241_change_assigned_user_id_column_in_tasks_table.php
+++ b/database/migrations/2023_10_30_195241_change_assigned_user_id_column_in_tasks_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ChangeAssignedUserIdColumnInTasksTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table
+                ->unsignedInteger('assigned_user_id')
+                ->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table
+                ->text('assigned_user_id')
+                ->change();
+        });
+    }
+}

--- a/database/migrations/2023_10_31_081229_rename_userid_column_to_client_id_column_in_invoices.php
+++ b/database/migrations/2023_10_31_081229_rename_userid_column_to_client_id_column_in_invoices.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class RenameUseridColumnToClientIdColumnInInvoices extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('invoices', function (Blueprint $table) {
+            $table->renameColumn(
+                'userid',
+                'client_id'
+            );
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('invoices', function (Blueprint $table) {
+            $table->renameColumn(
+                'client_id',
+                'userid'
+            );
+        });
+    }
+}

--- a/database/migrations/2023_10_31_081245_change_client_id_column_in_invoices.php
+++ b/database/migrations/2023_10_31_081245_change_client_id_column_in_invoices.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ChangeClientIdColumnInInvoices extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('invoices', function (Blueprint $table) {
+            $table
+                ->unsignedInteger('client_id')
+                ->nullable(false)
+                ->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('invoices', function (Blueprint $table) {
+            $table
+                ->text('client_id')
+                ->nullable(true)
+                ->change();
+        });
+    }
+}

--- a/database/migrations/2023_11_01_123805_change_starts_at_column_in_projects_table.php
+++ b/database/migrations/2023_11_01_123805_change_starts_at_column_in_projects_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ChangeStartsAtColumnInProjectsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table
+                ->date('starts_at')
+                ->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table
+                ->text('starts_at')
+                ->change();
+        });
+    }
+}

--- a/database/migrations/2023_11_01_123947_rename_deadline_column_to_deadline_at_column_in_projects_table.php
+++ b/database/migrations/2023_11_01_123947_rename_deadline_column_to_deadline_at_column_in_projects_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class RenameDeadlineColumnToDeadlineAtColumnInProjectsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table->renameColumn(
+                'deadline',
+                'deadline_at'
+            );
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table->renameColumn(
+                'deadline_at',
+                'deadline'
+            );
+        });
+    }
+}

--- a/database/migrations/2023_11_01_124010_change_deadline_at_column_in_projects_table.php
+++ b/database/migrations/2023_11_01_124010_change_deadline_at_column_in_projects_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ChangeDeadlineAtColumnInProjectsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table
+                ->date('deadline_at')
+                ->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table
+                ->text('deadline_at')
+                ->change();
+        });
+    }
+}

--- a/database/migrations/2023_11_01_125628_rename_invoiceid_column_to_invoice_id_column_in_payment_receipts_table.php
+++ b/database/migrations/2023_11_01_125628_rename_invoiceid_column_to_invoice_id_column_in_payment_receipts_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class RenameInvoiceidColumnToInvoiceIdColumnInPaymentReceiptsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('payment_receipts', function (Blueprint $table) {
+            $table->renameColumn(
+                'invoiceid',
+                'invoice_id'
+            );
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('payment_receipts', function (Blueprint $table) {
+            $table->renameColumn(
+                'invoice_id',
+                'invoiceid'
+            );
+        });
+    }
+}

--- a/database/migrations/2023_11_01_125641_change_invoice_id_column_in_payment_receipts_table.php
+++ b/database/migrations/2023_11_01_125641_change_invoice_id_column_in_payment_receipts_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ChangeInvoiceIdColumnInPaymentReceiptsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('payment_receipts', function (Blueprint $table) {
+            $table
+                ->unsignedInteger('invoice_id')
+                ->nullable(false)
+                ->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('payment_receipts', function (Blueprint $table) {
+            $table
+                ->text('invoiceid')
+                ->nullable(true)
+                ->change();
+        });
+    }
+}

--- a/database/migrations/2023_11_01_125659_rename_adminid_column_to_creator_id_column_in_payment_receipts_table.php
+++ b/database/migrations/2023_11_01_125659_rename_adminid_column_to_creator_id_column_in_payment_receipts_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class RenameAdminidColumnToCreatorIdColumnInPaymentReceiptsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('payment_receipts', function (Blueprint $table) {
+            $table->renameColumn(
+                'adminid',
+                'creator_id'
+            );
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('payment_receipts', function (Blueprint $table) {
+            $table->renameColumn(
+                'creator_id',
+                'adminid'
+            );
+        });
+    }
+}

--- a/database/migrations/2023_11_01_125709_change_creator_id_column_in_payment_receipts_table.php
+++ b/database/migrations/2023_11_01_125709_change_creator_id_column_in_payment_receipts_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ChangeCreatorIdColumnInPaymentReceiptsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('payment_receipts', function (Blueprint $table) {
+            $table
+                ->unsignedInteger('creator_id')
+                ->nullable(false)
+                ->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('payment_receipts', function (Blueprint $table) {
+            $table
+                ->text('creator_id')
+                ->nullable(true)
+                ->change();
+        });
+    }
+}

--- a/database/migrations/2023_11_01_185521_add_payment_gateway_id_column_to_payment_receipts_table.php
+++ b/database/migrations/2023_11_01_185521_add_payment_gateway_id_column_to_payment_receipts_table.php
@@ -1,0 +1,58 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+class AddPaymentGatewayIdColumnToPaymentReceiptsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::transaction(function () {
+            Schema::table('payment_receipts', function (Blueprint $table) {
+                $table
+                    ->foreignId('payment_gateway_id')
+                    ->nullable(true);
+            });
+
+            $paymentGateways = (
+                DB::table('payment_gateways')
+                    ->pluck('id', 'gatewayname')
+            );
+
+            foreach ( $paymentGateways as $name => $id ) {
+                DB::table('payment_receipts')
+                    ->where('gateway', $name)
+                    ->update([
+                        'payment_gateway_id' => $id,
+                    ]);
+            }
+
+            Schema::table('payment_receipts', function (Blueprint $table) {
+                $table
+                    ->foreignId('payment_gateway_id')
+                    ->nullable(false)
+                    ->change();
+            });
+        });
+
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('payment_receipts', function (Blueprint $table) {
+            $table->dropColumn('payment_gateway_id');
+        });
+    }
+}

--- a/database/migrations/2023_11_01_190819_drop_gateway_column_in_payment_receipts_table.php
+++ b/database/migrations/2023_11_01_190819_drop_gateway_column_in_payment_receipts_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class DropGatewayColumnInPaymentReceiptsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('payment_receipts', function (Blueprint $table) {
+            $table->dropColumn(
+                'gateway'
+            );
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('payment_receipts', function (Blueprint $table) {
+            $table
+                ->text('gateway')
+                ->nullable();
+        });
+    }
+}

--- a/database/migrations/2023_11_01_203134_change_amount_column_in_payment_receipts_table.php
+++ b/database/migrations/2023_11_01_203134_change_amount_column_in_payment_receipts_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ChangeAmountColumnInPaymentReceiptsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('payment_receipts', function (Blueprint $table) {
+            $table
+                ->unsignedBigInteger('amount')
+                ->nullable(false)
+                ->default(0)
+                ->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('payment_receipts', function (Blueprint $table) {
+            $table
+                ->text('amount')
+                ->nullable(true)
+                ->change();
+        });
+    }
+}

--- a/database/migrations/2023_11_01_203756_change_amount_column_in_projects_table.php
+++ b/database/migrations/2023_11_01_203756_change_amount_column_in_projects_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ChangeAmountColumnInProjectsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table
+                ->unsignedBigInteger('amount')
+                ->nullable(false)
+                ->default(0)
+                ->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table
+                ->text('amount')
+                ->nullable(true)
+                ->change();
+        });
+    }
+}

--- a/database/migrations/2023_11_01_203959_change_amount_column_in_expense_managers_table.php
+++ b/database/migrations/2023_11_01_203959_change_amount_column_in_expense_managers_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ChangeAmountColumnInExpenseManagersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('expense_managers', function (Blueprint $table) {
+            $table
+                ->unsignedBigInteger('amount')
+                ->nullable(false)
+                ->default(0)
+                ->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('expense_managers', function (Blueprint $table) {
+            $table
+                ->text('amount')
+                ->nullable(true)
+                ->change();
+        });
+    }
+}

--- a/database/migrations/2023_11_01_204013_change_amount_per_item_column_in_invoice_items_table.php
+++ b/database/migrations/2023_11_01_204013_change_amount_per_item_column_in_invoice_items_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ChangeAmountPerItemColumnInInvoiceItemsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('invoice_items', function (Blueprint $table) {
+            $table
+                ->unsignedBigInteger('amount_per_item')
+                ->nullable(false)
+                ->default(0)
+                ->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('invoice_items', function (Blueprint $table) {
+            $table
+                ->text('amount_per_item')
+                ->nullable(true)
+                ->change();
+        });
+    }
+}

--- a/database/migrations/2023_11_01_204211_change_totalamount_column_in_invoices_table.php
+++ b/database/migrations/2023_11_01_204211_change_totalamount_column_in_invoices_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ChangeTotalamountColumnInInvoicesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('invoices', function (Blueprint $table) {
+            $table
+                ->unsignedBigInteger('totalamount')
+                ->nullable(false)
+                ->default(0)
+                ->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('invoices', function (Blueprint $table) {
+            $table
+                ->text('totalamount')
+                ->nullable(true)
+                ->change();
+        });
+    }
+}

--- a/database/migrations/2023_11_01_204218_change_paidamount_column_in_invoices_table.php
+++ b/database/migrations/2023_11_01_204218_change_paidamount_column_in_invoices_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ChangePaidamountColumnInInvoicesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('invoices', function (Blueprint $table) {
+            $table
+                ->unsignedBigInteger('paidamount')
+                ->nullable(false)
+                ->default(0)
+                ->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('invoices', function (Blueprint $table) {
+            $table
+                ->text('paidamount')
+                ->nullable(true)
+                ->change();
+        });
+    }
+}

--- a/database/migrations/2023_11_01_204226_change_taxamount_column_in_invoices_table.php
+++ b/database/migrations/2023_11_01_204226_change_taxamount_column_in_invoices_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ChangeTaxamountColumnInInvoicesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('invoices', function (Blueprint $table) {
+            $table
+                ->unsignedBigInteger('taxamount')
+                ->nullable(false)
+                ->default(0)
+                ->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('invoices', function (Blueprint $table) {
+            $table
+                ->text('taxamount')
+                ->nullable(true)
+                ->change();
+        });
+    }
+}

--- a/resources/views/admin/settings/_settingsmenu.blade.php
+++ b/resources/views/admin/settings/_settingsmenu.blade.php
@@ -1,38 +1,45 @@
 <div class="dropdown-menu dropdown-menu-demo">
     <span class="dropdown-header">Settings</span>
-    <a class="dropdown-item   @if(Request::is('admin/settings')){{ 'active' }}@endif" href="/admin/settings">
-      
+    <a @class([
+        'dropdown-item',
+        'active' => request()->routeIs('admin.settings.*'),
+    ]) href="{{ route('admin.settings.show') }}">
 	<svg xmlns="http://www.w3.org/2000/svg" style="margin-right: 10px;"class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M10.325 4.317c.426 -1.756 2.924 -1.756 3.35 0a1.724 1.724 0 0 0 2.573 1.066c1.543 -.94 3.31 .826 2.37 2.37a1.724 1.724 0 0 0 1.065 2.572c1.756 .426 1.756 2.924 0 3.35a1.724 1.724 0 0 0 -1.066 2.573c.94 1.543 -.826 3.31 -2.37 2.37a1.724 1.724 0 0 0 -2.572 1.065c-.426 1.756 -2.924 1.756 -3.35 0a1.724 1.724 0 0 0 -2.573 -1.066c-1.543 .94 -3.31 -.826 -2.37 -2.37a1.724 1.724 0 0 0 -1.065 -2.572c-1.756 -.426 -1.756 -2.924 0 -3.35a1.724 1.724 0 0 0 1.066 -2.573c-.94 -1.543 .826 -3.31 2.37 -2.37c1 .608 2.296 .07 2.572 -1.065z" /><circle cx="12" cy="12" r="3" /></svg>
         Settings Overview
     </a>
-    <a class="dropdown-item   @if(Request::is('admin/settings/business')){{ 'active' }}@endif" href="/admin/settings/business">     
+    <a @class([
+        'dropdown-item',
+        'active' => request()->routeIs('admin.settings.business.*'),
+    ]) href="{{ route('admin.settings.business.show') }}">
 	<svg xmlns="http://www.w3.org/2000/svg" style="margin-right: 10px;" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M14 3v4a1 1 0 0 0 1 1h4" /><path d="M17 21h-10a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h7l5 5v11a2 2 0 0 1 -2 2z" /><line x1="9" y1="7" x2="10" y2="7" /><line x1="9" y1="13" x2="15" y2="13" /><line x1="13" y1="17" x2="15" y2="17" /></svg>
         Business Informations
     </a>
-
-    <a class="dropdown-item   @if(Request::is('admin/settings/billing')){{ 'active' }}@endif" href="/admin/settings/billing">    
+    <a @class([
+        'dropdown-item',
+        'active' => request()->routeIs( 'admin.settings.billing.*' ),
+    ]) href="{{ route('admin.settings.billing.show') }}">
      <svg xmlns="http://www.w3.org/2000/svg" style="margin-right: 10px;" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M14 3v4a1 1 0 0 0 1 1h4" /><path d="M17 21h-10a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h7l5 5v11a2 2 0 0 1 -2 2z" /><line x1="9" y1="7" x2="10" y2="7" /><line x1="9" y1="13" x2="15" y2="13" /><line x1="13" y1="17" x2="15" y2="17" /></svg>
          Billing Configuration
      </a>
-
-     <a class="dropdown-item   @if(Request::is('admin/settings/invoice')){{ 'active' }}@endif" href="/admin/settings/invoice">    
+     <a @class([
+        'dropdown-item',
+        'active' =>  request()->routeIs( 'admin.settings.invoice.*' ),
+     ]) href="{{ route('admin.settings.invoice.show') }}">
         <svg xmlns="http://www.w3.org/2000/svg" style="margin-right: 10px;" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M14 3v4a1 1 0 0 0 1 1h4" /><path d="M17 21h-10a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h7l5 5v11a2 2 0 0 1 -2 2z" /><line x1="9" y1="7" x2="10" y2="7" /><line x1="9" y1="13" x2="15" y2="13" /><line x1="13" y1="17" x2="15" y2="17" /></svg>
            Customize Invoice
         </a>
-   
 </div>
 <br><br>
 <div class="dropdown-menu dropdown-menu-demo">
     <span class="dropdown-header">Payment Gateways</span>
-
-    
-	  
-
-         <a class="dropdown-item  @if(Request::is('admin/settings/paymentgateway')){{ 'active' }}@endif" href="/admin/settings/paymentgateway">            
+         <a @class([
+            'dropdown-item',
+            'active' => request()->routeIs('admin.settings.payment-gateway.*'),
+         ]) href="{{ route('admin.settings.payment-gateway.show') }}">
 	        <svg xmlns="http://www.w3.org/2000/svg" style="margin-right: 10px;" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M17 8v-3a1 1 0 0 0 -1 -1h-10a2 2 0 0 0 0 4h12a1 1 0 0 1 1 1v3m0 4v3a1 1 0 0 1 -1 1h-12a2 2 0 0 1 -2 -2v-12" /><path d="M20 12v4h-4a2 2 0 0 1 0 -4h4" /></svg>
                Manage Payment Gateways
         </a>
-        <a class="dropdown-item  " href="https://docs.coderprokit.com/contact-us/support">            
+        <a class="dropdown-item" href="https://docs.coderprokit.com/contact-us/support">
 	        <svg xmlns="http://www.w3.org/2000/svg" style="margin-right: 10px;" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M17 8v-3a1 1 0 0 0 -1 -1h-10a2 2 0 0 0 0 4h12a1 1 0 0 1 1 1v3m0 4v3a1 1 0 0 1 -1 1h-12a2 2 0 0 1 -2 -2v-12" /><path d="M20 12v4h-4a2 2 0 0 1 0 -4h4" /></svg>
                Need Other Gateways ?
         </a>

--- a/resources/views/app/cashbook.blade.php
+++ b/resources/views/app/cashbook.blade.php
@@ -116,7 +116,7 @@
           </div>
             <div class="col-md-2">					
               <label class="form-label" style="margin-bottom: 0px;  padding-left:2px; font-size:13px;">Project</label>
-              <select class="form-select  form-select-sm" name="filter[userid]">
+              <select class="form-select  form-select-sm" name="filter[client_id]">
                
                 <option value="">Select Project</option>
                    @foreach($projects as $project)        

--- a/resources/views/app/editinvoice.blade.php
+++ b/resources/views/app/editinvoice.blade.php
@@ -7,7 +7,7 @@
         <div class="col-md-3">
             <div class="dropdown-menu dropdown-menu-demo">
                 <span class="dropdown-header">Menu</span>
-                <a class="dropdown-item " href="/invoices/{{ $invoice->id }}">
+                <a class="dropdown-item" href="{{ route('invoices.edit', [ $invoice ]) }}">
 	            <svg xmlns="http://www.w3.org/2000/svg" style="margin-right: 10px;" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M14 3v4a1 1 0 0 0 1 1h4" /><path d="M17 21h-10a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h7l5 5v11a2 2 0 0 1 -2 2z" /><line x1="9" y1="7" x2="10" y2="7" /><line x1="9" y1="13" x2="15" y2="13" /><line x1="13" y1="17" x2="15" y2="17" /></svg>
                      View Invoice
                 </a>
@@ -45,7 +45,7 @@
                          Edit Invoice
                     </a>
                 
-                <a class="dropdown-item " href="/invoices/cancel/{{$invoice->id}}" onclick="return confirm('Are you sure?')">
+                <a class="dropdown-item " href="{{ route('cancelinvoice', [ $invoice ]) }}" onclick="return confirm('Are you sure?')">
                   <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" style="margin-right: 10px;" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M5 21v-16m2 -2h10a2 2 0 0 1 2 2v10m0 4.01v1.99l-3 -2l-2 2l-2 -2l-2 2l-2 -2l-3 2" /><line x1="11" y1="7" x2="15" y2="7" /><line x1="9" y1="11" x2="11" y2="11" /><line x1="13" y1="15" x2="15" y2="15" /><line x1="15" y1="11" x2="15" y2="11.01" /><line x1="3" y1="3" x2="21" y2="21" /></svg>
                          Cancel Invoice
                     </a>
@@ -89,7 +89,7 @@
 
                 @php $todaydate = date('Y-m-d'); @endphp
                 @if($todaydate<$invoice->recorringnextdate)
-                                    <a class="dropdown-item " href="/invoices/cancelrecurring/{{$invoice->id}}" onclick="return confirm('Are you sure?')">
+                                    <a class="dropdown-item " href="{{ route('cancelrecurring', [ $invoice ]) }}" onclick="return confirm('Are you sure?')">
                      <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24"  style="margin-right: 10px;" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><circle cx="12" cy="12" r="9" /><path d="M10 10l4 4m0 -4l-4 4" /></svg>
                            Cancel Recurring Invoice
                 </a>  
@@ -149,7 +149,7 @@
                         <dd class="col-7"><strong>{{$invoice->title}}</strong></dd>
                         @if($invoice->project)
                         <dt class="col-5">Project:</dt>
-                        <dd class="col-7"><strong><a href="/projects/{{$invoice->project_id}}">{{$invoice->project->name}} </a></strong></dd>
+                        <dd class="col-7"><strong><a href="{{ route('projects.show', [ $invoice->project ]) }}">{{$invoice->project->name}} </a></strong></dd>
                         @endif
                         <dt class="col-5">Date:</dt>
                         <dd class="col-7">  {{$invoice->invodate}}</dd>
@@ -350,7 +350,7 @@
                                 </td>
                                   
                                   <td>
-                                    <a onclick="return confirm('Are you sure?')" href="/invoices/reversepayment/{{$payment->id}}/{{$invoice->id}}" class="btn btn-warning btn-sm"  style="color: #fff;">Del</a>
+                                    <a onclick="return confirm('Are you sure?')" href="{{ route('deletepayment', [ $payment, $invoice ]) }}" class="btn btn-warning btn-sm"  style="color: #fff;">Del</a>
                                 </td>
                               
                           </tr>

--- a/resources/views/app/editinvoice.blade.php
+++ b/resources/views/app/editinvoice.blade.php
@@ -404,7 +404,7 @@
                 </div>
                 <form action="{{route('invopaymentsave')}}" method="post">
                     @csrf
-                    <input type="hidden" name="invoiceid" value="{{$invoice->id}}">
+                    <input type="hidden" name="invoice_id" value="{{$invoice->id}}">
                 <div class="modal-body">
                     <div class="mb-2">
                         
@@ -447,7 +447,7 @@
                 </div>
                 <form action="{{route('refundinvoice')}}" method="post">
                     @csrf
-                    <input type="hidden" name="invoiceid" value="{{$invoice->id}}">
+                    <input type="hidden" name="invoice_id" value="{{$invoice->id}}">
                 <div class="modal-body">
                     <div class="mb-2">
                         

--- a/resources/views/app/editinvoice.blade.php
+++ b/resources/views/app/editinvoice.blade.php
@@ -250,7 +250,7 @@
                                     </form>
                                   </td>
                                   <td>
-                                    <form method="post" action="{{ route('invoices.items.destroy', []) }}" onsubmit="return confirm('Are you sure?')">
+                                    <form method="post" action="{{ route('invoices.items.destroy', [ $invoice, $invoiceItem ]) }}" onsubmit="return confirm('Are you sure?')">
                                       @csrf
                                       @method('DELETE')
                                       <button type="submit" class="btn btn-warning btn-sm" style="color: #fff;">Del</button>

--- a/resources/views/app/editinvoice.blade.php
+++ b/resources/views/app/editinvoice.blade.php
@@ -494,7 +494,7 @@
                   
                   <div class="mb-2">
                       <label class="form-label">Payment Link</label>
-                      <input type="text" class="form-control" placeholder="Payment link" value="@php echo URL::to('/');@endphp/invoices/pay/{{$invoice->id}}">
+                      <input type="text" class="form-control" placeholder="Payment link" value="{{ \Illuminate\Support\Facades\URL::signedRoute('invoices.pay', [ $invoice ]) }}">
                   </div>
                   
               </div>

--- a/resources/views/app/editquote.blade.php
+++ b/resources/views/app/editquote.blade.php
@@ -32,7 +32,7 @@
             <div class="dropdown-menu dropdown-menu-demo">
                 <span class="dropdown-header">Actions</span>
            
-                <a class="dropdown-item " href="/quotes/convert/{{$invoice->id}}" onclick="return confirm('Are you sure?')">
+                <a class="dropdown-item " href="{{ route('converttoinvo', [ $invoice ]) }}" onclick="return confirm('Are you sure?')">
                
 	                <svg xmlns="http://www.w3.org/2000/svg" class="icon" style="margin-right: 10px;"  width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M14 3v4a1 1 0 0 0 1 1h4" /><path d="M17 21h-10a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h7l5 5v11a2 2 0 0 1 -2 2z" /><line x1="9" y1="7" x2="10" y2="7" /><line x1="9" y1="13" x2="15" y2="13" /><line x1="13" y1="17" x2="15" y2="17" /></svg>
                        Convert To Invoice
@@ -42,13 +42,13 @@
                       <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" style="margin-right: 10px;" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M9 7h-3a2 2 0 0 0 -2 2v9a2 2 0 0 0 2 2h9a2 2 0 0 0 2 -2v-3" /><path d="M9 15h3l8.5 -8.5a1.5 1.5 0 0 0 -3 -3l-8.5 8.5v3" /><line x1="16" y1="5" x2="19" y2="8" /></svg>
                                Edit Quote
                           </a>     
-                    <a class="dropdown-item " href="/quotes/stat/{{$invoice->id}}/2" onclick="return confirm('Are you sure?')">
+                    <a class="dropdown-item " href="{{ route('quotestatuschange', [ $invoice, 2 ]) }}" onclick="return confirm('Are you sure?')">
                      
                       <svg xmlns="http://www.w3.org/2000/svg" class="icon" style="margin-right: 10px;" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M7 12l5 5l10 -10" /><path d="M2 12l5 5m5 -5l5 -5" /></svg>
                                   Mark as Approved
                               </a>  
 
-                    <a class="dropdown-item " href="/quotes/stat/{{$invoice->id}}/4" onclick="return confirm('Are you sure?')">
+                    <a class="dropdown-item " href="{{ route('quotestatuschange', [ $invoice, 4]) }}" onclick="return confirm('Are you sure?')">
                       <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" style="margin-right: 10px;" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M5 21v-16m2 -2h10a2 2 0 0 1 2 2v10m0 4.01v1.99l-3 -2l-2 2l-2 -2l-2 2l-2 -2l-3 2" /><line x1="11" y1="7" x2="15" y2="7" /><line x1="9" y1="11" x2="11" y2="11" /><line x1="13" y1="15" x2="15" y2="15" /><line x1="15" y1="11" x2="15" y2="11.01" /><line x1="3" y1="3" x2="21" y2="21" /></svg>
                              Cancel Quote
                         </a>
@@ -393,7 +393,7 @@
                   
                   <div class="mb-2">
                       <label class="form-label">Public Link</label>
-                      <input type="text" class="form-control" placeholder="Public link" value="@php echo URL::to('/');@endphp/quotes/public/{{$invoice->id}}">
+                      <input type="text" class="form-control" placeholder="Public link" value="{{ route('viewquotepublic', [ $invoice ]) }}">
                   </div>
                   
               </div>

--- a/resources/views/app/editquote.blade.php
+++ b/resources/views/app/editquote.blade.php
@@ -302,7 +302,7 @@
                 </div>
                 <form action="{{route('invopaymentsave')}}" method="post">
                     @csrf
-                    <input type="hidden" name="invoiceid" value="{{$invoice->id}}">
+                    <input type="hidden" name="invoice_id" value="{{$invoice->id}}">
                 <div class="modal-body">
                     <div class="mb-2">
                         
@@ -345,7 +345,7 @@
                 </div>
                 <form action="{{route('refundinvoice')}}" method="post">
                     @csrf
-                    <input type="hidden" name="invoiceid" value="{{$invoice->id}}">
+                    <input type="hidden" name="invoice_id" value="{{$invoice->id}}">
                 <div class="modal-body">
                     <div class="mb-2">
                         

--- a/resources/views/app/listofexpenses.blade.php
+++ b/resources/views/app/listofexpenses.blade.php
@@ -139,7 +139,7 @@
           </div>
             <div class="col-md-2">					
               <label class="form-label" style="margin-bottom: 0px;  padding-left:2px; font-size:13px;">Project</label>
-              <select class="form-select  form-select-sm" name="filter[userid]">
+              <select class="form-select  form-select-sm" name="filter[client_id]">
                
                 <option value="">Select Project</option>
                    @foreach($projects as $project)        

--- a/resources/views/app/listofexpenses.blade.php
+++ b/resources/views/app/listofexpenses.blade.php
@@ -195,8 +195,10 @@
                    # {{$expense->id }}
                 </td>
                 <td> {{$expense->item}}</td>
-                <td> 
-                  <a href="/projects/{{ !empty($expense->project) ? $expense->project->id:'' }}">   {{ !empty($expense->project) ? $expense->project->name:'' }} </a>
+                <td>
+                  @if ( $expense->project )
+                    <a href="{{ route('projects.show', [ $expense->project ]) }}">{{ $expense->project->name }}</a>
+                  @endif
                 </td>
                 <td>
                     {{$expense->amount}}
@@ -216,10 +218,11 @@
                             <a class="dropdown-item" data-toggle="modal" data-target="#editexpense{{$expense->id}}" href="#"    >
                                 Edit expense
                             </a>
-                            <a class="dropdown-item" onclick="return confirm('Are you sure?')"
-                                href="/expenses/delete/{{$expense->id}}">
-                                Delete expense
-                            </a>
+                            <form method="post" action="{{ route('expenses.destroy', [ $expense ]) }}" onsubmit="return confirm('Are you sure?')">
+                              @csrf
+                              @method('DELETE')
+                              <button type="submit" class="dropdown-item">Delete expense</button>
+                            </form>
                         </div>
                     </span>
                 </td>

--- a/resources/views/app/listofinvoices.blade.php
+++ b/resources/views/app/listofinvoices.blade.php
@@ -144,7 +144,7 @@
               <label class="form-label" style="margin-bottom: 0px;  padding-left:2px; font-size:13px;">Client</label>
               <x-select-client
                 class="form-select-sm"
-                name="filter[userid]"
+                name="filter[client_id]"
               />
             </div>
             <div class="col-md-2">					
@@ -276,7 +276,7 @@
             <div class="mb-2">
                 <label class="form-label">Select Client <a href="{{route('clients.create')}}" style="float:right;"> Add New Client </a></label>
                 <x-select-client
-                  name="userid"
+                  name="client_id"
                   id="select-users"
                 />
             </div>

--- a/resources/views/app/listofinvoices.blade.php
+++ b/resources/views/app/listofinvoices.blade.php
@@ -23,7 +23,11 @@
               </span>
             </div>
             <div class="col">
-              <a href="{{ route('invoices.index') }}?filter%5Binvostatus%5D=1" style="text-decoration: none;"><div class="font-weight-medium">
+              <a href="{{ route('invoices.index', [
+                'filter' => [
+                  'invostatus' => 1,
+                ]
+              ]) }}" style="text-decoration: none;"><div class="font-weight-medium">
                 {{$counts['unpaid']}}  Unpaid Invoices
               </div>
               </a>
@@ -52,7 +56,11 @@
             </div>
             <div class="col">
               <div class="font-weight-medium">
-                <a href="{{ route('invoices.index') }}?filter%5Binvostatus%5D=2" style="text-decoration: none;">   {{$counts['partially_paid']}}  Partpaid Invoices </a>
+                <a href="{{ route('invoices.index', [
+                  'filter' => [
+                    'invostatus' => 2,
+                  ]
+                ]) }}" style="text-decoration: none;">   {{$counts['partially_paid']}}  Partpaid Invoices </a>
               </div> 
               <div class="text-muted">
               
@@ -78,7 +86,11 @@
             </div>
             <div class="col">
               <div class="font-weight-medium">
-                <a href="{{ route('invoices.index') }}?filter%5Binvostatus%5D=3" style="text-decoration: none;">  {{$counts['paid']}}  Paid Invoices </a>
+                <a href="{{ route('invoices.index', [
+                  'filter' => [
+                    'invostatus' => 3,
+                  ]
+                ]) }}" style="text-decoration: none;">  {{$counts['paid']}}  Paid Invoices </a>
               </div>
               <div class="text-muted">
                
@@ -103,7 +115,11 @@
             </div>
             <div class="col">
               <div class="font-weight-medium">
-                <a href="{{ route('invoices.index') }}?filter%5Binvostatus%5D=5" style="text-decoration: none;">  {{$counts['cancelled']}}  Canceled Invoices </a>
+                <a href="{{ route('invoices.index', [
+                  'filter' => [
+                    'invostatus' => 5,
+                  ]
+                ]) }}" style="text-decoration: none;">  {{$counts['cancelled']}}  Canceled Invoices </a>
               </div>
               <div class="text-muted">
                
@@ -227,7 +243,7 @@
                         <button class="btn btn-sm dropdown-toggle align-text-top"
                             data-boundary="viewport" data-toggle="dropdown">Actions</button>
                         <div class="dropdown-menu dropdown-menu-right">
-                            <a class="dropdown-item" href="/invoices/edit/{{$invoice->id}}">
+                            <a class="dropdown-item" href="{{ route('invoices.edit', [ $invoice ]) }}">
                                 Edit Invoice
                             </a>
                             <form method="post" action="{{ route('invoices.destroy', [ $invoice ]) }}" onsubmit="return confirm('Are you sure?')">

--- a/resources/views/app/listofinvoices.blade.php
+++ b/resources/views/app/listofinvoices.blade.php
@@ -296,6 +296,12 @@
                   id="select-users"
                 />
             </div>
+            <div class="mb-2">
+                <label class="form-label">Select project</label>
+                <x-select-project
+                  name="project_id"
+                />
+            </div>
             
            
         </div>

--- a/resources/views/app/listofquotes.blade.php
+++ b/resources/views/app/listofquotes.blade.php
@@ -32,7 +32,7 @@
             <label class="form-label" style="margin-bottom: 0px;  padding-left:2px; font-size:13px;">Client</label>
             <x-select-client
               class="form-select-sm"
-              name="filter[userid]"
+              name="filter[client_id]"
             />
           </div>
           <div class="col-md-2">					
@@ -150,7 +150,7 @@
             <div class="mb-2">
                 <label class="form-label">Select Client <a href="{{route('clients.create')}}" style="float:right;"> Add New Client </a></label>
                 <x-select-client
-                  name="userid"
+                  name="client_id"
                   id="select-users"
                 />
             </div>

--- a/resources/views/app/listofquotes.blade.php
+++ b/resources/views/app/listofquotes.blade.php
@@ -81,7 +81,7 @@
                 <td><a href="{{ route('offers.edit', [ $invoice ]) }}"> {{$invoice->title}}</a></td>
                 <td>
                   @if ( $invoice->client )
-                    <a href="{{ routes('clients.show', [ $invoice->client ]) }}">{{ $invoice->client->name }}</a>
+                    <a href="{{ route('clients.show', [ $invoice->client ]) }}">{{ $invoice->client->name }}</a>
                   @else
                     <span>Removed</span>
                   @endif
@@ -103,7 +103,7 @@
                         <button class="btn btn-sm dropdown-toggle align-text-top"
                             data-boundary="viewport" data-toggle="dropdown">Actions</button>
                         <div class="dropdown-menu dropdown-menu-right">
-                            <a class="dropdown-item" href="/invoices/edit/{{$invoice->id}}">
+                            <a class="dropdown-item" href="{{ route('invoices.edit', [ $invoice ]) }}">
                                 Edit Quote
                             </a>
                             <form method="post" action="{{ route('invoices.destroy', [ $invoice ]) }}" onsubmit="return confirm('Are you sure?')">

--- a/resources/views/app/mytasks.blade.php
+++ b/resources/views/app/mytasks.blade.php
@@ -44,8 +44,8 @@
                   <div class="row">
                     <div class="col">
                       <div class="avatar-list avatar-list-stacked">
-                        @if($task->assignedto)                          
-                       <span class="avatar  rounded-circle" data-toggle="tooltip" data-placement="bottom" style="background-image: url({{$task->assigned->profile_photo_url}})" title="Assigned to : {{$task->assigned->name}} "></span>                      
+                        @if($task->is_assigned)
+                       <span class="avatar  rounded-circle" data-toggle="tooltip" data-placement="bottom" style="background-image: url({{$task->assignedUser->profile_photo_url}})" title="Assigned to : {{$task->assignedUser->name}} "></span>
                          @endif
                    
                        

--- a/resources/views/app/payinvoice.blade.php
+++ b/resources/views/app/payinvoice.blade.php
@@ -306,7 +306,7 @@ $footerimagedataUri = 'data:image/' . $footerimagetype . ';base64,' . base64_enc
                               
                                 <form role="form" action="{{ route('stripepayment') }}" method="post" class="require-validation" data-cc-on-file="false" data-stripe-publishable-key="{{$gateway->apikey}}" id="payment-form">
                                    @csrf
-                                   <input type="hidden" name="invoid" value="{{$invoice->id}}">
+                                   <input type="hidden" name="invoice_id" value="{{$invoice->id}}">
                                   <div class="row"> 
                                  <div class="col-md-12">
                                     <div class="mb-2">
@@ -401,7 +401,8 @@ $footerimagedataUri = 'data:image/' . $footerimagetype . ';base64,' . base64_enc
                            
                     
                             
-                                <form action="{!!route('razorpaypayment')!!}" method="POST" >                        
+                                <form action="{{ route('razorpaypayment') }}" method="POST">
+                                  @csrf
                                     <script  src="https://checkout.razorpay.com/v1/checkout.js"
                                             data-key="{{$gateway->apikey}}"
                                             data-amount="{{$balanceamount}}00"
@@ -414,8 +415,8 @@ $footerimagedataUri = 'data:image/' . $footerimagetype . ';base64,' . base64_enc
                                             data-prefill.email="{{$invoice->client->email}}"
                                             data-theme.color="#2b81c2">
                                     </script>
-                                    <input type="hidden" name="_token" value="{!!csrf_token()!!}">
-                                    <input type="hidden" name="invoid" value="{{$invoice->id}}">
+
+                                    <input type="hidden" name="invoice_id" value="{{$invoice->id}}">
                                 </form>
                           
                         </div>

--- a/resources/views/app/softwareupdate.blade.php
+++ b/resources/views/app/softwareupdate.blade.php
@@ -20,7 +20,7 @@
         
          
          <div>
-           <a href="/runupdate" class="btn btn-primary w-100">
+           <a href="{{ route('runupdate') }}" class="btn btn-primary w-100">
             <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-refresh" width="32" height="32" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
                 <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
                 <path d="M20 11a8.1 8.1 0 0 0 -15.5 -2m-.5 -4v4h4"></path>

--- a/resources/views/app/viewinvoice.blade.php
+++ b/resources/views/app/viewinvoice.blade.php
@@ -182,7 +182,7 @@ $footerimagedataUri = 'data:image/' . $footerimagetype . ';base64,' . base64_enc
             <div class="col-md-3">
                 <div class="dropdown-menu dropdown-menu-demo">
                     <span class="dropdown-header">Menu</span>
-                    <a class="dropdown-item " href="/invoices/edit/{{$invoice->id}}">
+                    <a class="dropdown-item " href="{{ route('invoices.edit', [ $invoice ]) }}">
                    
                 	<svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24"   style="margin-right: 10px;" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M9 7h-3a2 2 0 0 0 -2 2v9a2 2 0 0 0 2 2h9a2 2 0 0 0 2 -2v-3" /><path d="M9 15h3l8.5 -8.5a1.5 1.5 0 0 0 -3 -3l-8.5 8.5v3" /><line x1="16" y1="5" x2="19" y2="8" /></svg>
                          Edit Invoice
@@ -196,11 +196,17 @@ $footerimagedataUri = 'data:image/' . $footerimagetype . ';base64,' . base64_enc
 	                <svg xmlns="http://www.w3.org/2000/svg"  style="margin-right: 10px;" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M11 7h-5a2 2 0 0 0 -2 2v9a2 2 0 0 0 2 2h9a2 2 0 0 0 2 -2v-5" /><line x1="10" y1="14" x2="20" y2="4" /><polyline points="15 4 20 4 20 9" /></svg>
                             Payment Link
                     </a>
-                    <a class="dropdown-item " href="/invoices/email/{{$invoice->id}}" onclick="return confirm('Are you sure?')"  >
-                       
-	                <svg xmlns="http://www.w3.org/2000/svg"  style="margin-right: 10px;" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><circle cx="12" cy="12" r="4" /><path d="M16 12v1.5a2.5 2.5 0 0 0 5 0v-1.5a9 9 0 1 0 -5.5 8.28" /></svg>
-                                Send Email
-                    </a>
+                    <form method="post" action="{{ route('invoices.invoice-email.send', [ $invoice ]) }}" onsubmit="return confirm('Are you sure?')">
+                      @csrf
+                      <button type="submit" class="dropdown-item">
+                        <svg xmlns="http://www.w3.org/2000/svg" style="margin-right: 10px;" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                          <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                          <circle cx="12" cy="12" r="4" />
+                          <path d="M16 12v1.5a2.5 2.5 0 0 0 5 0v-1.5a9 9 0 1 0 -5.5 8.28" />
+                        </svg>
+                        <span>Send Email</span>
+                      </button>
+                    </form>
                     <a class="dropdown-item " href="#"  onclick="printDiv('invoice')">            
                             
                 	<svg xmlns="http://www.w3.org/2000/svg"  style="margin-right: 10px;" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M17 17h2a2 2 0 0 0 2 -2v-4a2 2 0 0 0 -2 -2h-14a2 2 0 0 0 -2 2v4a2 2 0 0 0 2 2h2" /><path d="M17 9v-4a2 2 0 0 0 -2 -2h-6a2 2 0 0 0 -2 2v4" /><rect x="7" y="13" width="10" height="8" rx="2" /></svg>

--- a/resources/views/app/viewinvoice.blade.php
+++ b/resources/views/app/viewinvoice.blade.php
@@ -241,7 +241,7 @@ $footerimagedataUri = 'data:image/' . $footerimagetype . ';base64,' . base64_enc
                   
                   <div class="mb-2">
                       <label class="form-label">Payment Link</label>
-                      <input type="text" class="form-control" placeholder="Payment link" value="@php echo URL::to('/');@endphp/invoices/pay/{{$invoice->id}}">
+                      <input type="text" class="form-control" placeholder="Payment link" value="{{ \Illuminate\Support\Facades\URL::signedRoute('invoices.pay', [ $invoice ]) }}">
                   </div>
                   
               </div>

--- a/resources/views/app/viewquote.blade.php
+++ b/resources/views/app/viewquote.blade.php
@@ -169,12 +169,18 @@ $dataUri = 'data:image/' . $type . ';base64,' . base64_encode($data);
 	                <svg xmlns="http://www.w3.org/2000/svg"  style="margin-right: 10px;" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M11 7h-5a2 2 0 0 0 -2 2v9a2 2 0 0 0 2 2h9a2 2 0 0 0 2 -2v-5" /><line x1="10" y1="14" x2="20" y2="4" /><polyline points="15 4 20 4 20 9" /></svg>
                             Public Link
                     </a>
-                    <a class="dropdown-item " href="/quotes/email/{{$invoice->id}}" onclick="return confirm('Are you sure?')"  >
-                       
-	                <svg xmlns="http://www.w3.org/2000/svg"  style="margin-right: 10px;" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><circle cx="12" cy="12" r="4" /><path d="M16 12v1.5a2.5 2.5 0 0 0 5 0v-1.5a9 9 0 1 0 -5.5 8.28" /></svg>
-                                Send Email
-                    </a>
-                    <a class="dropdown-item " href="#"  onclick="printDiv('invoice')">            
+                    <form method="post" action="{{ route('offers.offer-email.send', [ $invoive ]) }}" onsubmit="return confirm('Are you sure?')">
+                      @csrf
+                      <button type="submit" class="dropdown-item">
+                        <svg xmlns="http://www.w3.org/2000/svg" style="margin-right: 10px;" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                          <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                          <circle cx="12" cy="12" r="4" />
+                          <path d="M16 12v1.5a2.5 2.5 0 0 0 5 0v-1.5a9 9 0 1 0 -5.5 8.28" />
+                        </svg>
+                        <span>Send Email</span>
+                      </button>
+                    </form>
+                    <a class="dropdown-item" href="#" onclick="printDiv('invoice')">
                             
                 	<svg xmlns="http://www.w3.org/2000/svg"  style="margin-right: 10px;" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M17 17h2a2 2 0 0 0 2 -2v-4a2 2 0 0 0 -2 -2h-14a2 2 0 0 0 -2 2v4a2 2 0 0 0 2 2h2" /><path d="M17 9v-4a2 2 0 0 0 -2 -2h-6a2 2 0 0 0 -2 2v4" /><rect x="7" y="13" width="10" height="8" rx="2" /></svg>
                                Print Quote
@@ -187,20 +193,20 @@ $dataUri = 'data:image/' . $type . ';base64,' . base64_encode($data);
             <div class="dropdown-menu dropdown-menu-demo">
               <span class="dropdown-header">Actions</span>
          
-              <a class="dropdown-item " href="/quotes/convert/{{$invoice->id}}" onclick="return confirm('Are you sure?')">
+              <a class="dropdown-item " href="{{ route('converttoinvo', [ $invoice ]) }}" onclick="return confirm('Are you sure?')">
              
                 <svg xmlns="http://www.w3.org/2000/svg" class="icon" style="margin-right: 10px;"  width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M14 3v4a1 1 0 0 0 1 1h4" /><path d="M17 21h-10a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h7l5 5v11a2 2 0 0 1 -2 2z" /><line x1="9" y1="7" x2="10" y2="7" /><line x1="9" y1="13" x2="15" y2="13" /><line x1="13" y1="17" x2="15" y2="17" /></svg>
                      Convert To Invoice
                   </a>
 
                          
-                  <a class="dropdown-item " href="/quotes/stat/{{$invoice->id}}/2" onclick="return confirm('Are you sure?')">
+                  <a class="dropdown-item" href="{{ route('quotestatuschange', [ $invoice, 2 ]) }}" onclick="return confirm('Are you sure?')">
                    
                     <svg xmlns="http://www.w3.org/2000/svg" class="icon" style="margin-right: 10px;" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M7 12l5 5l10 -10" /><path d="M2 12l5 5m5 -5l5 -5" /></svg>
                                 Mark as Approved
                             </a>  
 
-                  <a class="dropdown-item " href="/quotes/stat/{{$invoice->id}}/4" onclick="return confirm('Are you sure?')">
+                  <a class="dropdown-item " href="{{ route('quotestatuschange', [ $invoice, 4 ]) }}" onclick="return confirm('Are you sure?')">
                     <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" style="margin-right: 10px;" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M5 21v-16m2 -2h10a2 2 0 0 1 2 2v10m0 4.01v1.99l-3 -2l-2 2l-2 -2l-2 2l-2 -2l-3 2" /><line x1="11" y1="7" x2="15" y2="7" /><line x1="9" y1="11" x2="11" y2="11" /><line x1="13" y1="15" x2="15" y2="15" /><line x1="15" y1="11" x2="15" y2="11.01" /><line x1="3" y1="3" x2="21" y2="21" /></svg>
                            Cancel Quote
                       </a>    
@@ -230,7 +236,7 @@ $dataUri = 'data:image/' . $type . ';base64,' . base64_encode($data);
                   
                   <div class="mb-2">
                       <label class="form-label">Public Link</label>
-                      <input type="text" class="form-control" placeholder="Payment link" value="@php echo URL::to('/');@endphp/quotes/public/{{$invoice->id}}">
+                      <input type="text" class="form-control" placeholder="Payment link" value="{{ route('viewquotepublic', [ $invoice ]) }}">
                   </div>
                   
               </div>

--- a/resources/views/app/viewquotepublic.blade.php
+++ b/resources/views/app/viewquotepublic.blade.php
@@ -258,13 +258,13 @@ $dataUri = 'data:image/' . $type . ';base64,' . base64_encode($data);
                     <span class="dropdown-header">Actions</span>
                 
                                
-                        <a class="dropdown-item " href="/quotes/stat/public/{{$invoice->id}}/2" onclick="return confirm('Are you sure?')">
+                        <a class="dropdown-item" href="{{ route('quotestatuschangepublic', [ $invoice, 2 ]) }}" onclick="return confirm('Are you sure?')">
                          
                           <svg xmlns="http://www.w3.org/2000/svg" class="icon" style="margin-right: 10px;" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M7 12l5 5l10 -10" /><path d="M2 12l5 5m5 -5l5 -5" /></svg>
                                       Accept  Quote
                                   </a>  
       
-                        <a class="dropdown-item " href="/quotes/stat/public/{{$invoice->id}}/3" onclick="return confirm('Are you sure?')">
+                        <a class="dropdown-item" href="{{ route('quotestatuschangepublic', [ $invoice, 3 ]) }}" onclick="return confirm('Are you sure?')">
                           <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" style="margin-right: 10px;" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M5 21v-16m2 -2h10a2 2 0 0 1 2 2v10m0 4.01v1.99l-3 -2l-2 2l-2 -2l-2 2l-2 -2l-3 2" /><line x1="11" y1="7" x2="15" y2="7" /><line x1="9" y1="11" x2="11" y2="11" /><line x1="13" y1="15" x2="15" y2="15" /><line x1="15" y1="11" x2="15" y2="11.01" /><line x1="3" y1="3" x2="21" y2="21" /></svg>
                                 Reject Quote
                             </a>    

--- a/resources/views/app/viewtask.blade.php
+++ b/resources/views/app/viewtask.blade.php
@@ -43,8 +43,8 @@
                     
                     <div class="col">
                       <div class="avatar-list avatar-list-stacked">
-                        @if($task->assignedto)                          
-                       <span class="avatar  rounded-circle" data-toggle="tooltip" data-placement="bottom" style="background-image: url({{$task->assigned->profile_photo_url}})" title="Assigned to : {{$task->assigned->name}} "></span>                      
+                        @if($task->is_assigned)
+                       <span class="avatar  rounded-circle" data-toggle="tooltip" data-placement="bottom" style="background-image: url({{$task->assignedUser->profile_photo_url}})" title="Assigned to : {{$task->assignedUser->name}} "></span>
                          @endif
                         
                        

--- a/resources/views/clients/index.blade.php
+++ b/resources/views/clients/index.blade.php
@@ -28,7 +28,7 @@
           
             @foreach($clients as $client)
             <tr>
-                <td><a href="/client/{{$client->id}}" class="text-reset" tabindex="-1"> {{$client->name}}</a></td>
+                <td><a href="{{ route('clients.show', [ $client ]) }}" class="text-reset" tabindex="-1"> {{$client->name}}</a></td>
                 <td>
                     
                     {{$client->business}}

--- a/resources/views/clients/show.blade.php
+++ b/resources/views/clients/show.blade.php
@@ -163,7 +163,7 @@
                           <td>
                               {{$project->starts_at}}
                           </td>
-                          <td> {{$project->deadline}}
+                          <td> {{$project->deadline_at}}
                           </td>  
                         
                           <td>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -366,7 +366,7 @@
             <div class="mb-2">
                 <label class="form-label">Select Client <a href="{{route('clients.create')}}" style="float:right;"> Add New Client </a></label>
                 <x-select-client
-                  name="userid"
+                  name="client_id"
                   id="select-users"
                 />
             </div>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -13,7 +13,11 @@
 
     <div class="row">
         <div class="col-md-3 mb-2">
-          <a href="{{ route('invoices.index') }}?filter[invostatus]=1">
+          <a href="{{ route('invoices.index', [
+            'filter' => [
+              'invostatus' => 1
+            ]
+          ]) }}">
             <div class="card card-sm">
                 <div class="card-body">
                   <div class="row align-items-center">
@@ -35,7 +39,11 @@
               </div></a>
         </div>
         <div class="col-md-3 mb-2"> 
-          <a href="{{ route('invoices.index') }}?filter[invostatus]=3">
+          <a href="{{ route('invoices.index', [
+            'filter' => [
+              'invostatus' => 3,
+            ]
+          ]) }}">
             <div class="card card-sm">
                 <div class="card-body">
                   <div class="row align-items-center">
@@ -59,7 +67,7 @@
         </div>
 
         <div class="col-md-3 mb-2">
-          <a href="/quotes">
+          <a href="{{ route('offers.index') }}">
             <div class="card card-sm">
                 <div class="card-body">
                   <div class="row align-items-center">
@@ -83,7 +91,11 @@
         </div>
 
         <div class="col-md-3 mb-2">
-          <a href="{{ route('projects.index') }}?filter[status]=2">
+          <a href="{{ route('projects.index', [
+            'filter' => [
+              'status' => 2
+            ]
+          ]) }}">
             <div class="card card-sm">
                 <div class="card-body">
                   <div class="row align-items-center">
@@ -294,7 +306,11 @@
                 </td>
                 <td><a href="{{ route('invoices.edit', [ $invoice ]) }}">{{ $invoice->title }}</a></td>
                 <td>
-                  <a href="/client/ {{ !empty($invoice->client) ? $invoice->client->id:'' }}">   {{ !empty($invoice->client) ? $invoice->client->name:'Removed' }} </a>
+                  @if ( $invoice->client )
+                    <a href="{{ route('clients.show', [ $invoice->client ]) }}">{{ $invoice->client->name }}</a>
+                  @else
+                    <span>Removed</span>
+                  @endif
                 </td>
                 <td>
                     {{$invoice->invodate}}
@@ -315,7 +331,7 @@
                             data-boundary="viewport" data-toggle="dropdown">Actions</button>
                         <div class="dropdown-menu dropdown-menu-right">
 
-                            <a class="dropdown-item" href="/invoices/edit/{{$invoice->id}}">
+                            <a class="dropdown-item" href="{{ route('invoices.edit', [ $invoice ]) }}">
                               {{ __('Edit_Invoice') }}
                             </a>
                           <form method="post" action="{{ route('invoices.destroy', [ $invoice ]) }}" onsubmit="return confirm('Are you sure?')">

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -213,8 +213,8 @@
                   <div class="row">
                     <div class="col">
                       <div class="avatar-list avatar-list-stacked">
-                        @if($task->assignedto)                          
-                       <span class="avatar  rounded-circle" data-toggle="tooltip" data-placement="bottom" style="background-image: url({{$task->assigned->profile_photo_url}})" title="Assigned to : {{$task->assigned->name}} "></span>                      
+                        @if($task->is_assigned)
+                       <span class="avatar  rounded-circle" data-toggle="tooltip" data-placement="bottom" style="background-image: url({{$task->assignedUser->profile_photo_url}})" title="Assigned to : {{$task->assignedUser->name}} "></span>
                          @endif
                    
                        

--- a/resources/views/emails/invoicemail.blade.php
+++ b/resources/views/emails/invoicemail.blade.php
@@ -14,7 +14,7 @@ Invoice Date : {{$invoice->invodate}}<br>
 
 
 
-@php $link = URL::to('/')."/invoices/pay/".$invoice->id; @endphp
+@php $link = \Illuminate\Support\Facades\URL::signedRoute('invoices.pay', [ $invoice ]); @endphp
 @component('mail::button', ['url' => $link ,  'color' => 'success'])
 View Invoice 
 @endcomponent

--- a/resources/views/emails/quotemail.blade.php
+++ b/resources/views/emails/quotemail.blade.php
@@ -8,9 +8,10 @@ Please find the details by clicking view quote button.
 
 
 
-
-@php $link = URL::to('/')."/quote/public/".$invoice->id; @endphp
-@component('mail::button', ['url' => $link ,  'color' => 'success'])
+@component('mail::button', [
+  'url' => route('viewquotepublic', [ $invoice ]),
+  'color' => 'success',
+])
 View Quote 
 @endcomponent
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -69,7 +69,10 @@
              
               <div class="collapse navbar-collapse" id="navbar-menu">
                 <ul class="navbar-nav pt-lg-3">
-                  <li class="nav-item  @if(Request::is('dashboard')){{ 'active' }}@endif">
+                  <li @class([
+                    'nav-item',
+                    'active' => Request::routeIs('dashboard'),
+                  ])>
                     <a class="nav-link" href="/" >
                       <span class="nav-link-icon d-md-none d-lg-inline-block">
                         <x-icon.dashboard />
@@ -80,7 +83,11 @@
                     </a>
                   </li>
 
-                  <li class="nav-item  @if(Request::is('clients')){{ 'active' }}@endif dropdown">
+                  <li @class([
+                    'nav-item',
+                    'dropdown',
+                    'active' => Request::routeIs('clients.*'),
+                  ])>
                     <a class="nav-link dropdown-toggle" href="#navbar-base" data-toggle="dropdown" role="button" aria-expanded="false" >
                       <span class="nav-link-icon d-md-none d-lg-inline-block">
                         <x-icon.client />
@@ -107,7 +114,11 @@
                     </ul>
                   </li>
 
-                  <li class="nav-item  @if(Request::is('invoices')){{ 'active' }}@endif dropdown">
+                  <li @class([
+                    'nav-item',
+                    'dropdown',
+                    'active' => Request::routeIs('invoices.*'),
+                  ])>
                     <a class="nav-link dropdown-toggle" href="#navbar-base" data-toggle="dropdown" role="button" aria-expanded="false" >
                       <span class="nav-link-icon d-md-none d-lg-inline-block">
                         <x-icon.invoice />
@@ -123,19 +134,31 @@
                         </a>
                       </li>
                       <li >
-                        <a class="dropdown-item" href="{{ route('invoices.index') }}?filter%5Btitle%5D=&filter%5Binvoid%5D=&filter%5Bclient_id%5D=&filter%5Binvostatus%5D=1" >
+                        <a class="dropdown-item" href="{{ route('invoices.index', [
+                          'filter' => [
+                            'invostatus' => 1,
+                          ]
+                        ]) }}">
                           {{ __('Unpaid Invoices') }}
                         </a>
                       </li>
 
                       <li >
-                        <a class="dropdown-item" href="{{ route('invoices.index') }}?filter%5Btitle%5D=&filter%5Binvoid%5D=&filter%5Bclient_id%5D=&filter%5Binvostatus%5D=2" >
+                        <a class="dropdown-item" href="{{ route('invoices.index', [
+                          'filter' => [
+                            'invostatus' => 2,
+                          ]
+                        ]) }}">
                           {{ __('Part paid Invoices') }}
                         </a>
                       </li> 
                       
                       <li >
-                        <a class="dropdown-item" href="{{ route('invoices.index') }}?filter%5Btitle%5D=&filter%5Binvoid%5D=&filter%5Bclient_id%5D=&filter%5Binvostatus%5D=3" >
+                        <a class="dropdown-item" href="{{ route('invoices.index', [
+                          'filter' => [
+                            'invostatus' => 3,
+                          ]
+                        ]) }}">
                           {{ __('Paid Invoices') }}
                         </a>
                       </li>                  
@@ -145,7 +168,11 @@
                     </ul>
                   </li>
 
-                  <li class="nav-item  @if(Request::is('quotes')){{ 'active' }}@endif dropdown">
+                  <li @class([
+                    'nav-item',
+                    'dropdown',
+                    'active' => Request::routeIs('offers.*'),
+                  ])>
                     <a class="nav-link dropdown-toggle" href="#navbar-base" data-toggle="dropdown" role="button" aria-expanded="false" >
                       <span class="nav-link-icon d-md-none d-lg-inline-block">
                         <x-icon.offer />
@@ -156,17 +183,25 @@
                     </a>
                     <ul class="dropdown-menu  ">
                       <li >
-                        <a class="dropdown-item" href="/quotes" >
+                        <a class="dropdown-item" href="{{ route('offers.index') }}">
                           {{ __('Quotation') }}
                         </a>
                       </li>
                       <li >
-                        <a class="dropdown-item" href="/quotes?filter%5Btitle%5D=&filter%5Bquoteid%5D=&filter%5Bclient_id%5D=&filter%5Bquotestat%5D=1" >
+                        <a class="dropdown-item" href="{{ route('offers.index', [
+                          'filter' => [
+                            'quotestat' => 1,
+                          ]
+                        ]) }}">
                           {{ __('Pending Quotes') }}
                         </a>
                       </li>
                       <li >
-                        <a class="dropdown-item" href="/quotes?filter%5Btitle%5D=&filter%5Bquoteid%5D=&filter%5Bclient_id%5D=&filter%5Bquotestat%5D=2" >
+                        <a class="dropdown-item" href="{{ route('offers.index', [
+                          'filter' => [
+                            'quotestat' => 2,
+                          ]
+                        ]) }}">
                           {{ __('Approved Quotes') }}
                         </a>
                       </li>
@@ -178,7 +213,11 @@
                   </li>
 
                   
-                  <li class="nav-item  @if(Request::is('projects')){{ 'active' }}@endif dropdown">
+                  <li @class([
+                    'nav-item',
+                    'dropdown',
+                    'active' => Request::routeIs('projects.*'),
+                  ])>
                     <a class="nav-link dropdown-toggle" href="#navbar-base" data-toggle="dropdown" role="button" aria-expanded="false" >
                       <span class="nav-link-icon d-md-none d-lg-inline-block">
                         <x-icon.project />
@@ -194,12 +233,20 @@
                         </a>
                       </li>
                       <li >
-                        <a class="dropdown-item" href="{{ route('projects.index') }}?filter%name%5D=&filter%5Bclient%5D=&filter%5Bstatus%5D=2" >
+                        <a class="dropdown-item" href="{{ route('projects.index', [
+                          'filter' => [
+                            'status' => 2,
+                          ]
+                        ]) }}">
                           {{ __('Ongoing Projects') }}
                         </a>
                       </li>
                       <li >
-                        <a class="dropdown-item" href="{{ route('projects.index') }}?filter%name%5D=&filter%5Bclient%5D=&filter%5Bstatus%5D=5" >
+                        <a class="dropdown-item" href="{{ route('projects.index', [
+                          'filter' => [
+                            'status' => 5,
+                          ]
+                        ]) }}">
                           {{ __('Completed Projects') }}
                         </a>
                       </li>
@@ -217,7 +264,11 @@
                   
 
                   
-                  <li class="nav-item  @if(Request::is('tasks')){{ 'active' }}@endif">
+                  <li @class([
+                    'nav-item',
+                    'dropdown',
+                    'active' => Request::routeIs('tasks.*'),
+                  ])>
                     <a class="nav-link" href="{{ route('tasks.index') }}">
                       <span class="nav-link-icon d-md-none d-lg-inline-block">
                         <x-icon.task />
@@ -228,8 +279,12 @@
                     </a>
                   </li>
 
-                  <li class="nav-item  @if(Request::is('expenses')){{ 'active' }}@endif">
-                    <a class="nav-link" href="/expenses" >
+                  <li @class([
+                    'nav-item',
+                    'dropdown',
+                    'active' => Request::routeIs('expenses.*'),
+                  ])>
+                    <a class="nav-link" href="{{ route('expenses.index') }}">
                       <span class="nav-link-icon d-md-none d-lg-inline-block">
                         <x-icon.expense />
                       </span>
@@ -241,7 +296,11 @@
 
                
 
-                  <li class="nav-item  @if(Request::is('file-manager')){{ 'active' }}@endif">
+                  <li @class([
+                    'nav-item',
+                    'dropdown',
+                    'active' => Request::is('file-manager'),
+                  ])>
                     <a class="nav-link" href="{{ route('file-manager') }}">
                       <span class="nav-link-icon d-md-none d-lg-inline-block">
                         <x-icon.file-manager />
@@ -253,7 +312,11 @@
                   </li>
                 
                   @if(Auth::user()->is_admin)
-                  <li class="nav-item  @if(Request::is('lead')){{ 'active' }}@endif dropdown">
+                  <li @class([
+                    'nav-item',
+                    'dropdown',
+                    'active' => Request::is('lead'),
+                  ])>
                     <a class="nav-link dropdown-toggle" href="#navbar-base" data-toggle="dropdown" role="button" aria-expanded="false" >
                       <span class="nav-link-icon d-md-none d-lg-inline-block">
                         <x-icon.admin-panel />
@@ -274,7 +337,7 @@
                         </a>
                       </li>
                       <li >
-                        <a class="dropdown-item" href="/admin/settings/invoice" >
+                        <a class="dropdown-item" href="{{ route('admin.settings.invoice.show') }}" >
                           {{ __('Customize Invoice') }}
                         </a>
                       </li>
@@ -296,7 +359,7 @@
               <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbar-menu">
                 <span class="navbar-toggler-icon"></span>
               </button>
-              <a href="/dashboard" class="navbar-brand navbar-brand-autodark d-none-navbar-horizontal pr-0 pr-md-3">
+              <a href="{{ route('dashboard') }}" class="navbar-brand navbar-brand-autodark d-none-navbar-horizontal pr-0 pr-md-3">
                 <img src="/storage/uploads/{{$settings->logo}}"  style="margin-top: -5px;" alt="{{$settings->companyname}}" class="navbar-brand-image">
               </a>
               </div>
@@ -385,7 +448,11 @@
                 <div class="d-flex flex-column flex-md-row flex-fill align-items-stretch align-items-md-center">
                   <ul class="navbar-nav">
                     
-                    <li class="nav-item  @if(Request::is('dashboard')){{ 'active' }}@endif">
+                    <li @class([
+                      'nav-item',
+                      'dropdown',
+                      'active' => Request::routeIs('dashboard'),
+                    ])>
                       <a class="nav-link" href="/" >
                         <span class="nav-link-icon d-md-none d-lg-inline-block">
                           <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-dashboard" width="32" height="32" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
@@ -401,7 +468,11 @@
                       </a>
                     </li>
   
-                    <li class="nav-item  @if(Request::is('clients')){{ 'active' }}@endif dropdown">
+                    <li @class([
+                      'nav-item',
+                      'dropdown',
+                      'active' => Request::routeIs('clients.*'),
+                    ])>
                       <a class="nav-link dropdown-toggle" href="#navbar-base" data-toggle="dropdown" role="button" aria-expanded="false" >
                         <span class="nav-link-icon d-md-none d-lg-inline-block">
                           <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><circle cx="9" cy="7" r="4" /><path d="M3 21v-2a4 4 0 0 1 4 -4h4a4 4 0 0 1 4 4v2" /><path d="M16 3.13a4 4 0 0 1 0 7.75" /><path d="M21 21v-2a4 4 0 0 0 -3 -3.85" /></svg>
@@ -412,12 +483,12 @@
                       </a>
                       <ul class="dropdown-menu  ">
                         <li >
-                          <a class="dropdown-item" href="/clients" >
+                          <a class="dropdown-item" href="{{ route('clients.index') }}">
                             {{ __('Client_Manager') }}
                           </a>
                         </li>
                         <li >
-                          <a class="dropdown-item" href="/client/add" >
+                          <a class="dropdown-item" href="{{ route('clients.create') }}">
                             {{ __('Add_New_Client') }}
                           </a>
                         </li>
@@ -428,7 +499,11 @@
                       </ul>
                     </li>
   
-                    <li class="nav-item  @if(Request::is('invoices')){{ 'active' }}@endif dropdown">
+                    <li @class([
+                      'nav-item',
+                      'dropdown',
+                      'active' => Request::routeIs('invoices.*'),
+                    ])>
                       <a class="nav-link dropdown-toggle" href="#navbar-base" data-toggle="dropdown" role="button" aria-expanded="false" >
                         <span class="nav-link-icon d-md-none d-lg-inline-block">
                           <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M14 3v4a1 1 0 0 0 1 1h4" /><path d="M17 21h-10a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h7l5 5v11a2 2 0 0 1 -2 2z" /><line x1="9" y1="7" x2="10" y2="7" /><line x1="9" y1="13" x2="15" y2="13" /><line x1="13" y1="17" x2="15" y2="17" /></svg>
@@ -444,13 +519,21 @@
                           </a>
                         </li>
                         <li >
-                          <a class="dropdown-item" href="{{ route('invoices.index') }}?filter%5Btitle%5D=&filter%5Binvoid%5D=&filter%5Bclient_id%5D=&filter%5Binvostatus%5D=1" >
+                          <a class="dropdown-item" href="{{ route('invoices.index', [
+                            'filter' => [
+                              'invostatus' => 1,
+                            ]
+                          ]) }}">
                             {{ __('Unpaid Invoices') }}
                           </a>
                         </li>
                         
                         <li >
-                          <a class="dropdown-item" href="{{ route('invoices.index') }}?filter%5Btitle%5D=&filter%5Binvoid%5D=&filter%5Bclient_id%5D=&filter%5Binvostatus%5D=3" >
+                          <a class="dropdown-item" href="{{ route('invoices.index', [
+                            'filter' => [
+                              'invostatus' => 3,
+                            ]
+                          ]) }}">
                             {{ __('Paid Invoices') }}
                           </a>
                         </li>                  
@@ -460,7 +543,11 @@
                       </ul>
                     </li>
   
-                    <li class="nav-item  @if(Request::is('quotes')){{ 'active' }}@endif dropdown">
+                    <li @class([
+                      'nav-item',
+                      'dropdown',
+                      'active' => Request::routeIs('offers.*'),
+                    ])>
                       <a class="nav-link dropdown-toggle" href="#navbar-base" data-toggle="dropdown" role="button" aria-expanded="false" >
                         <span class="nav-link-icon d-md-none d-lg-inline-block">
                           <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-quote" width="32" height="32" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
@@ -475,17 +562,25 @@
                       </a>
                       <ul class="dropdown-menu  ">
                         <li >
-                          <a class="dropdown-item" href="/quotes" >
+                          <a class="dropdown-item" href="{{ route('offers.index') }}" >
                             {{ __('Quotation') }}
                           </a>
                         </li>
                         <li >
-                          <a class="dropdown-item" href="/quotes?filter%5Btitle%5D=&filter%5Bquoteid%5D=&filter%5Bclient_id%5D=&filter%5Bquotestat%5D=1" >
+                          <a class="dropdown-item" href="{{ route('offers.index', [
+                            'filter' => [
+                              'quotestat' => 1,
+                            ]
+                          ]) }}">
                             {{ __('Pending Quotes') }}
                           </a>
                         </li>
                         <li >
-                          <a class="dropdown-item" href="/quotes?filter%5Btitle%5D=&filter%5Bquoteid%5D=&filter%5Bclient_id%5D=&filter%5Bquotestat%5D=2" >
+                          <a class="dropdown-item" href="{{ route('offers.index', [
+                            'filter' => [
+                              'quotestat' => 2,
+                            ]
+                          ]) }}">
                             {{ __('Approved Quotes') }}
                           </a>
                         </li>
@@ -497,7 +592,11 @@
                     </li>
   
                     
-                    <li class="nav-item  @if(Request::is('projects')){{ 'active' }}@endif dropdown">
+                    <li @class([
+                      'nav-item',
+                      'dropdown',
+                      'active' => Request::routeIs('projects.*'),
+                    ])>
                       <a class="nav-link dropdown-toggle" href="#navbar-base" data-toggle="dropdown" role="button" aria-expanded="false" >
                         <span class="nav-link-icon d-md-none d-lg-inline-block">
                           <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-adjustments-alt" width="32" height="32" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
@@ -524,12 +623,20 @@
                           </a>
                         </li>
                         <li >
-                          <a class="dropdown-item" href="{{ route('projects.index') }}?filter%5Bname%5D=&filter%5Bclient%5D=&filter%5Bstatus%5D=2" >
+                          <a class="dropdown-item" href="{{ route('projects.index', [
+                            'filter' => [
+                              'status' => 2,
+                            ]
+                          ]) }}">
                             {{ __('Ongoing Projects') }}
                           </a>
                         </li>
                         <li >
-                          <a class="dropdown-item" href="{{ route('projects.index') }}?filter%5Bname%5D=&filter%5Bclient%5D=&filter%5Bstatus%5D=5" >
+                          <a class="dropdown-item" href="{{ route('projects.index', [
+                            'filter' => [
+                              'status' => 5,
+                            ]
+                          ]) }}">
                             {{ __('Completed Projects') }}
                           </a>
                         </li>
@@ -547,7 +654,11 @@
                     
   
                     
-                    <li class="nav-item  @if(Request::is('tasks')){{ 'active' }}@endif">
+                    <li @class([
+                      'nav-item',
+                      'dropdown',
+                      'active' => Request::routeIs('tasks.*'),
+                    ])>
                       <a class="nav-link" href="{{ route('tasks.index') }}" >
                         <span class="nav-link-icon d-md-none d-lg-inline-block">
                           <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><rect x="4" y="4" width="6" height="6" rx="1" /><rect x="4" y="14" width="6" height="6" rx="1" /><rect x="14" y="14" width="6" height="6" rx="1" /><line x1="14" y1="7" x2="20" y2="7" /><line x1="17" y1="4" x2="17" y2="10" /></svg>
@@ -558,8 +669,12 @@
                       </a>
                     </li>
   
-                    <li class="nav-item  @if(Request::is('expenses')){{ 'active' }}@endif">
-                      <a class="nav-link" href="/expenses" >
+                    <li @class([
+                      'nav-item',
+                      'dropdown',
+                      'active' => Request::routeIs('expenses.*'),
+                    ])>
+                      <a class="nav-link" href="{{ route('expenses.index') }}">
                         <span class="nav-link-icon d-md-none d-lg-inline-block">
                           <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-wallet" width="32" height="32" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
                             <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
@@ -575,7 +690,11 @@
   
                  
   
-                    <li class="nav-item  @if(Request::is('file-manager')){{ 'active' }}@endif">
+                    <li @class([
+                      'nav-item',
+                      'dropdown',
+                      'active' => Request::is('file-manager'),
+                    ])>
                       <a class="nav-link" href="{{ route('file-manager') }}">
                         <span class="nav-link-icon d-md-none d-lg-inline-block">
                           <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-cloud-upload" width="32" height="32" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
@@ -592,7 +711,11 @@
                     </li>
                   
                     @if(Auth::user()->is_admin)
-                    <li class="nav-item  @if(Request::is('lead')){{ 'active' }}@endif dropdown">
+                    <li @class([
+                      'nav-item',
+                      'dropdown',
+                      'active' => Request::is('lead'),
+                    ])>
                       <a class="nav-link dropdown-toggle" href="#navbar-base" data-toggle="dropdown" role="button" aria-expanded="false" >
                         <span class="nav-link-icon d-md-none d-lg-inline-block"><svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z"/><polyline points="12 3 20 7.5 20 16.5 12 21 4 16.5 4 7.5 12 3" /><line x1="12" y1="12" x2="20" y2="7.5" /><line x1="12" y1="12" x2="12" y2="21" /><line x1="12" y1="12" x2="4" y2="7.5" /><line x1="16" y1="5.25" x2="8" y2="9.75" /></svg>
                         </span>
@@ -612,7 +735,7 @@
                           </a>
                         </li>
                         <li >
-                          <a class="dropdown-item" href="/admin/settings/invoice" >
+                          <a class="dropdown-item" href="{{ route('admin.settings.invoice.show') }}">
                             {{ __('Customize Invoice') }}
                           </a>
                         </li>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -311,7 +311,7 @@
                     </a>
                   </li>
                 
-                  @if(Auth::user()->is_admin)
+                  @if( auth()->user()->is_admin )
                   <li @class([
                     'nav-item',
                     'dropdown',
@@ -411,10 +411,10 @@
 
                 <div class="nav-item dropdown">
                   <a href="#" class="nav-link d-flex lh-1 text-reset p-0" data-bs-toggle="dropdown" aria-label="Open user menu">
-                    <span class="avatar avatar-sm" style="background-image: url({{ Auth::user()->profile_photo_url }})"></span>
+                    <span class="avatar avatar-sm" style="background-image: url({{ auth()->user()->profile_photo_url }})"></span>
                     <div class="d-none d-xl-block ps-2">
-                      <div>{{ Auth::user()->name }}</div>
-                      <div class="mt-1 small text-muted">{{ Auth::user()->email }}</div>
+                      <div>{{ auth()->user()->name }}</div>
+                      <div class="mt-1 small text-muted">{{ auth()->user()->email }}</div>
                     </div>
                   </a>
                   <div class="dropdown-menu dropdown-menu-end dropdown-menu-arrow">
@@ -710,7 +710,7 @@
                       </a>
                     </li>
                   
-                    @if(Auth::user()->is_admin)
+                    @if( auth()->user()->is_admin )
                     <li @class([
                       'nav-item',
                       'dropdown',

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -123,19 +123,19 @@
                         </a>
                       </li>
                       <li >
-                        <a class="dropdown-item" href="{{ route('invoices.index') }}?filter%5Btitle%5D=&filter%5Binvoid%5D=&filter%5Buserid%5D=&filter%5Binvostatus%5D=1" >
+                        <a class="dropdown-item" href="{{ route('invoices.index') }}?filter%5Btitle%5D=&filter%5Binvoid%5D=&filter%5Bclient_id%5D=&filter%5Binvostatus%5D=1" >
                           {{ __('Unpaid Invoices') }}
                         </a>
                       </li>
 
                       <li >
-                        <a class="dropdown-item" href="{{ route('invoices.index') }}?filter%5Btitle%5D=&filter%5Binvoid%5D=&filter%5Buserid%5D=&filter%5Binvostatus%5D=2" >
+                        <a class="dropdown-item" href="{{ route('invoices.index') }}?filter%5Btitle%5D=&filter%5Binvoid%5D=&filter%5Bclient_id%5D=&filter%5Binvostatus%5D=2" >
                           {{ __('Part paid Invoices') }}
                         </a>
                       </li> 
                       
                       <li >
-                        <a class="dropdown-item" href="{{ route('invoices.index') }}?filter%5Btitle%5D=&filter%5Binvoid%5D=&filter%5Buserid%5D=&filter%5Binvostatus%5D=3" >
+                        <a class="dropdown-item" href="{{ route('invoices.index') }}?filter%5Btitle%5D=&filter%5Binvoid%5D=&filter%5Bclient_id%5D=&filter%5Binvostatus%5D=3" >
                           {{ __('Paid Invoices') }}
                         </a>
                       </li>                  
@@ -161,12 +161,12 @@
                         </a>
                       </li>
                       <li >
-                        <a class="dropdown-item" href="/quotes?filter%5Btitle%5D=&filter%5Bquoteid%5D=&filter%5Buserid%5D=&filter%5Bquotestat%5D=1" >
+                        <a class="dropdown-item" href="/quotes?filter%5Btitle%5D=&filter%5Bquoteid%5D=&filter%5Bclient_id%5D=&filter%5Bquotestat%5D=1" >
                           {{ __('Pending Quotes') }}
                         </a>
                       </li>
                       <li >
-                        <a class="dropdown-item" href="/quotes?filter%5Btitle%5D=&filter%5Bquoteid%5D=&filter%5Buserid%5D=&filter%5Bquotestat%5D=2" >
+                        <a class="dropdown-item" href="/quotes?filter%5Btitle%5D=&filter%5Bquoteid%5D=&filter%5Bclient_id%5D=&filter%5Bquotestat%5D=2" >
                           {{ __('Approved Quotes') }}
                         </a>
                       </li>
@@ -444,13 +444,13 @@
                           </a>
                         </li>
                         <li >
-                          <a class="dropdown-item" href="{{ route('invoices.index') }}?filter%5Btitle%5D=&filter%5Binvoid%5D=&filter%5Buserid%5D=&filter%5Binvostatus%5D=1" >
+                          <a class="dropdown-item" href="{{ route('invoices.index') }}?filter%5Btitle%5D=&filter%5Binvoid%5D=&filter%5Bclient_id%5D=&filter%5Binvostatus%5D=1" >
                             {{ __('Unpaid Invoices') }}
                           </a>
                         </li>
                         
                         <li >
-                          <a class="dropdown-item" href="{{ route('invoices.index') }}?filter%5Btitle%5D=&filter%5Binvoid%5D=&filter%5Buserid%5D=&filter%5Binvostatus%5D=3" >
+                          <a class="dropdown-item" href="{{ route('invoices.index') }}?filter%5Btitle%5D=&filter%5Binvoid%5D=&filter%5Bclient_id%5D=&filter%5Binvostatus%5D=3" >
                             {{ __('Paid Invoices') }}
                           </a>
                         </li>                  
@@ -480,12 +480,12 @@
                           </a>
                         </li>
                         <li >
-                          <a class="dropdown-item" href="/quotes?filter%5Btitle%5D=&filter%5Bquoteid%5D=&filter%5Buserid%5D=&filter%5Bquotestat%5D=1" >
+                          <a class="dropdown-item" href="/quotes?filter%5Btitle%5D=&filter%5Bquoteid%5D=&filter%5Bclient_id%5D=&filter%5Bquotestat%5D=1" >
                             {{ __('Pending Quotes') }}
                           </a>
                         </li>
                         <li >
-                          <a class="dropdown-item" href="/quotes?filter%5Btitle%5D=&filter%5Bquoteid%5D=&filter%5Buserid%5D=&filter%5Bquotestat%5D=2" >
+                          <a class="dropdown-item" href="/quotes?filter%5Btitle%5D=&filter%5Bquoteid%5D=&filter%5Bclient_id%5D=&filter%5Bquotestat%5D=2" >
                             {{ __('Approved Quotes') }}
                           </a>
                         </li>

--- a/resources/views/projects/index.blade.php
+++ b/resources/views/projects/index.blade.php
@@ -78,8 +78,11 @@
                 </td>
                 <td><a href="{{ route('projects.show', [ $project ]) }}"> {{$project->name}}</a></td>
                 <td>
-                  <a href="/client/ {{ !empty($project->client) ? $project->client->id:'' }}">   {{ !empty($project->client) ? $project->client->name:'Removed' }} </a>
-                 
+                  @if ( $project->client )
+                    <a href="{{ route('clients.show', [ $project->client ]) }}">{{ $project->client->name }}</a>
+                  @else
+                    <span>Removed</span>
+                  @endif
                 </td>
                 <td>
                     {{$project->starts_at}}

--- a/resources/views/projects/index.blade.php
+++ b/resources/views/projects/index.blade.php
@@ -87,7 +87,7 @@
                 <td>
                     {{$project->starts_at}}
                 </td>
-                <td> {{$project->deadline}}
+                <td> {{$project->deadline_at}}
                 </td>  
               
                 <td>
@@ -148,7 +148,7 @@
             </div>
             <div class="mb-2">
                 <label class="form-label">DeadLine</label>
-                <input type="date" value="@php echo date('Y-m-d'); @endphp" class="form-control" name="deadline" placeholder="DeadLine">
+                <input type="date" value="@php echo date('Y-m-d'); @endphp" class="form-control" name="deadline_at" placeholder="DeadLine">
             </div>
             
            

--- a/resources/views/projects/show.blade.php
+++ b/resources/views/projects/show.blade.php
@@ -78,7 +78,7 @@
               <dd class="col-7"><strong>{{$project->name}}</strong></dd>
               <dt class="col-5">Client:</dt>
               <dd class="col-7">
-                <a href="/client/{{$project->client->id}}">{{$project->client->name}}</a>
+                <a href="{{ route('clients.show', [ $project->client ]) }}">{{$project->client->name}}</a>
               </dd>
               <dt class="col-5">Start Date:</dt>
               <dd class="col-7"><strong>{{$project->starts_at}}</strong></dd>
@@ -284,7 +284,7 @@
                   <span class="dropdown ml-1">
                     <button class="btn btn-white btn-sm dropdown-toggle align-text-top"data-boundary="viewport" data-toggle="dropdown">Actions</button>
                     <div class="dropdown-menu dropdown-menu-right">
-                      <a class="dropdown-item" href="/invoices/edit/{{ $invoice->id }}">{{ __('Edit_Invoice') }}</a>
+                      <a class="dropdown-item" href="{{ route('invoices.edit', [ $invoice ]) }}">{{ __('Edit_Invoice') }}</a>
                       <form method="post" action="{{ route('invoices.destroy', [ $invoice ]) }}" onsubmit="return confirm('Are you sure?')">
                         @csrf
                         @method('DELETE')

--- a/resources/views/projects/show.blade.php
+++ b/resources/views/projects/show.blade.php
@@ -83,7 +83,7 @@
               <dt class="col-5">Start Date:</dt>
               <dd class="col-7"><strong>{{$project->starts_at}}</strong></dd>
               <dt class="col-5">Deadline:</dt>
-              <dd class="col-7"><strong>{{$project->deadline}}</strong></dd>
+              <dd class="col-7"><strong>{{$project->deadline_at}}</strong></dd>
               <dt class="col-5">Status:</dt>
               <dd class="col-7">
                 <x-project-status :project="$project" />
@@ -100,9 +100,9 @@
       <div class="col-md-4">
         <div class="card">
           <div class="card-body p-4 py-3 text-center">
-            <span class="avatar avatar-xl mb-2 avatar-rounded @if($today>$project->deadline) bg-red-lt  @else bg-green-lt  @endif">{{$balanceDays}}</span>
+            <span class="avatar avatar-xl mb-2 avatar-rounded @if($today>$project->deadline_at) bg-red-lt  @else bg-green-lt  @endif">{{$balanceDays}}</span>
 
-            @if ( $today > $project->deadline )
+            @if ( $today > $project->deadline_at )
               <h3 class="mb-0">Days Overdue</h3>
             @else
               <h3 class="mb-0">Days Left</h3>
@@ -111,7 +111,7 @@
         </div>
       </div>
       <div class="progress card-progress">
-        <div class="progress-bar @if ( $today > $project->deadline ) bg-red  @else bg-green @endif" style="width: {{ $percentage }}%" role="progressbar" aria-valuenow="{{ $percentage }}" aria-valuemin="0" aria-valuemax="100">
+        <div class="progress-bar @if ( $today > $project->deadline_at ) bg-red  @else bg-green @endif" style="width: {{ $percentage }}%" role="progressbar" aria-valuenow="{{ $percentage }}" aria-valuemin="0" aria-valuemax="100">
           <span class="visually-hidden">{{ $percentage }}% Complete</span>
         </div>
       </div>
@@ -351,7 +351,7 @@
           </div>
           <div class="mb-2">
             <label class="form-label">DeadLine</label>
-            <input type="date" value="{{ $project->deadline }}" class="form-control" name="deadline" placeholder="DeadLine" />
+            <input type="date" value="{{ $project->deadline_at }}" class="form-control" name="deadline_at" placeholder="DeadLine" />
           </div>
         </div>
         <div class="modal-footer">

--- a/resources/views/projects/show.blade.php
+++ b/resources/views/projects/show.blade.php
@@ -377,7 +377,7 @@
       </div>
       <form action="{{ route('invoices.store') }}" method="post">
         @csrf
-        <input type="hidden" value="{{ $project->client->id }}" name="userid" />
+        <input type="hidden" value="{{ $project->client->id }}" name="client_id" />
         <input type="hidden" value="{{ $project->id }}" name="project_id" />
         <div class="modal-body">
           <div class="mb-2">

--- a/resources/views/projects/tasks.blade.php
+++ b/resources/views/projects/tasks.blade.php
@@ -32,7 +32,7 @@
                 </div>
                 <div class="mb-3">
                     <label class="form-label">Assigned To</label>
-                    <select class="form-select" name="assignedto">
+                    <select class="form-select" name="assigned_user_id">
                         <option value="bg-azure">Select User</option>
                         @foreach($users as $user)
                             <option value="{{$user->id}}">{{$user->name}}</option>
@@ -90,8 +90,8 @@
                     <div class="row">
                       <div class="col">
                         <div class="avatar-list avatar-list-stacked">
-                          @if($task->assignedto)                          
-                         <span class="avatar  rounded-circle" data-toggle="tooltip" data-placement="bottom" style="background-image: url({{$task->assigned->profile_photo_url}})" title="Assigned to : {{$task->assigned->name}} "></span>                      
+                          @if($task->is_assigned)
+                         <span class="avatar  rounded-circle" data-toggle="tooltip" data-placement="bottom" style="background-image: url({{$task->assignedUser->profile_photo_url}})" title="Assigned to : {{$task->assignedUser->name}} "></span>
                            @endif
                      
                          

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -25,7 +25,7 @@
             @if (Route::has('login'))
                 <div class="hidden fixed top-0 right-0 px-6 py-4 sm:block">
                     @auth
-                        <a href="{{ url('/dashboard') }}" class="text-sm text-gray-700 underline">Dashboard</a>
+                        <a href="{{ route('dashboard') }}" class="text-sm text-gray-700 underline">Dashboard</a>
                     @else
                         <a href="{{ route('login') }}" class="text-sm text-gray-700 underline">Login</a>
 


### PR DESCRIPTION
This pull request unifies a lot of database table columns, either by their name or by their data type, mostly by both cases. In a follow-up pull request I will introduce a currency column for all money related tables, an `default_currency` option in settings and for each client, and will make use of a [money handling package](https://github.com/moneyphp/money).

Also the table `invoices` will be split into `invoices`, `offers`, and `subscriptions` (for recurring invoices).